### PR TITLE
Add support for durative-actions

### DIFF
--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -225,10 +225,8 @@ class Effect(object):
             return "({op} ({var}) {effects})".format(op=self.operator, var=self.obj, effects=list2str(self.subeffects))
         elif self.operator == EffectOperator.WHEN:
             return "({op} {goal} {effects})".format(op=self.operator, goal=self.goal, effects=list2str(self.subeffects))
-        elif self.operator == EffectOperator.NOT:
-            return "({op} {atoms})".format(op=self.operator, atoms=self.atom)
         else:
-            return "({op} {effects})".format(op=self.operator, effects=list2str(self.subeffects | (self.atom or set())))
+            return "({op} {effects})".format(op=self.operator, effects=list2str(self.subeffects))
 
     def __str__(self):
         return self.__repr_()

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -72,6 +72,9 @@ class Atom(object):
     def __repr__(self):
         return "{} {}".format(self.predicate, list2str(self.variables))
 
+    def __eq__(self, other):
+        return isinstance(other, Atom) and other.predicate == self.predicate and other.variables == self.variables
+
     def ground(self, varvals):
         g = [ varvals[v] if v in varvals else v for v in self.predicate ]
         return tuple(g)
@@ -98,6 +101,9 @@ class Obj():
     def __str__(self):
         return ", ".join(["{}={}".format(name, value) if value else name
                           for name, value in self.variable_list.items()])
+
+    def __eq__(self, other):
+        return isinstance(other, Obj) and self.variable_list == other.variable_list
 
 
 class GoalOperator(Enum):
@@ -157,6 +163,10 @@ class Goal(object):
 
     def __str__(self):
         return self.__repr_()
+
+    def __eq__(self, other):
+        return isinstance(other, Goal) and \
+               self.operator == other.operator and self.subgoals == other.subgoals and self.obj == other.obj
 
 
 class EffectOperator(Enum):
@@ -222,6 +232,11 @@ class Effect(object):
 
     def __str__(self):
         return self.__repr_()
+
+    def __eq__(self, other):
+        return isinstance(other, Effect) and \
+               self.atom == other.atom and self.operator == other.operator and \
+               self.subeffects == other.subeffects and self.obj == other.obj and self.goal is other.goal
 
 
 class DurationOperator(Enum):

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -48,7 +48,7 @@ def get_operator(ctx, operator_cls):
     return operator_cls(operator_name)
 
 
-class Atom:
+class Atom(object):
 
     def __init__(self, ctx):
         self.predicate = None
@@ -105,7 +105,7 @@ class GoalOperator(Enum):
     OVER_ALL = "over all"
 
 
-class Goal:
+class Goal(object):
     atoms = None
     operator = None
     subgoals = None
@@ -160,7 +160,7 @@ class EffectOperator(Enum):
     AT_END = "at end"
 
 
-class Effect:
+class Effect(object):
     atoms = None
     operator = None
     subeffects = None
@@ -227,7 +227,7 @@ class DurationOperator(Enum):
     EQ = "= ?duration"
 
 
-class Duration:
+class Duration(object):
     operator = None
     subdurations = None
     value = None

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -50,9 +50,16 @@ def get_operator(ctx, operator_cls):
 
 class Atom(object):
 
-    def __init__(self, ctx):
+    def __init__(self, predicate, variables=None):
         self.predicate = None
         self.variables = []
+        if isinstance(predicate, pddlParser.AtomicTermFormulaContext):
+            self._init_from_ctx(predicate)
+        else:
+            self.predicate = predicate
+            self.variables = variables
+
+    def _init_from_ctx(self, ctx):
         from antlr4.tree.Tree import TerminalNodeImpl
         for child in ctx.getChildren():
             if isinstance(child, TerminalNodeImpl):

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -131,10 +131,10 @@ class Goal(object):
             self.atom = atom
         elif operator in [GoalOperator.AND, GoalOperator.OR]:
             assert hasattr(subgoals, "__iter__") and all(isinstance(goal, Goal) for goal in subgoals)
-            self.subgoals = set(subgoals)
+            self.subgoals = tuple(subgoals)
         elif operator == GoalOperator.NOT:
             assert isinstance(subgoals, Goal)
-            self.subgoals = {subgoals}
+            self.subgoals = (subgoals,)
         elif operator == GoalOperator.IMPLY:
             assert hasattr(subgoals, "__len__") and len(subgoals) == 2 and all(isinstance(goal, Goal) for goal in subgoals)
             self.subgoals = tuple(subgoals)
@@ -192,21 +192,21 @@ class Effect(object):
             self.atom = atom
         elif operator == EffectOperator.AND:
             assert all(isinstance(effect, Effect) for effect in subeffects)
-            self.subeffects = set(subeffects)
+            self.subeffects = tuple(subeffects)
         elif operator == EffectOperator.NOT:
             assert isinstance(subeffects, Effect)
-            self.subeffects = {subeffects}
+            self.subeffects = (subeffects,)
         elif operator == EffectOperator.WHEN:
             assert isinstance(goal, Goal) and isinstance(subeffects, Effect)
             self.goal = goal
-            self.subeffects = {subeffects}
+            self.subeffects = (subeffects,)
         elif operator == EffectOperator.FORALL:
             assert isinstance(obj, Obj) and isinstance(subeffects, Effect)
             self.obj = obj
-            self.subeffects = {subeffects}
+            self.subeffects = (subeffects,)
         elif operator in [EffectOperator.AT_START, EffectOperator.AT_END]:
             assert isinstance(subeffects, Effect)
-            self.subeffects = {subeffects}
+            self.subeffects = (subeffects,)
 
     def recursive_atoms(self):
         if self.atom:
@@ -264,7 +264,7 @@ class Duration(object):
             self.value = value
         elif operator in [DurationOperator.AT_START, DurationOperator.AT_END]:
             assert isinstance(subdurations, Duration)
-            self.subdurations = set([subdurations])
+            self.subdurations = {subdurations}
 
     def __repr_(self):
         if self.operator is None:

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -57,7 +57,7 @@ class Atom(object):
             self._init_from_ctx(predicate)
         else:
             self.predicate = predicate
-            self.variables = variables
+            self.variables = list(variables)
 
     def _init_from_ctx(self, ctx):
         from antlr4.tree.Tree import TerminalNodeImpl


### PR DESCRIPTION
This pull request rewrites many parts of `pddl.py`. The changes are probably not backward compatible. For this, the following features are added:

* No more distinguish between precondition_pos and *_neg, but new class `Goal` that allows to nest `Goal`s with all possible operators: and, or,  not, imply, exits, ...
* Similar for effect: New class `Effect` with operators: and, not, when,  forall, ...
* Support for `durative-action`:
  * with goal operators at start, at end, over all
  * with effect operators at start, at end
  * support for durations
* probably some more things :-)