### PR TITLE
Phase 3 — Action costs (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ operators carry `precondition_num` / `effect_num`, and `State` tracks a numeric
 valuation so the planners respect constraints like `(>= (fuel ?v) 10)` and
 effects like `(decrease (fuel ?v) 5)`.
 
+Action costs (`:action-costs`, `(increase (total-cost) ...)`, `(:metric minimize
+(total-cost))`) are supported too. `DomainProblem.metric()` exposes the metric,
+`Plan.cost` reports the accumulated `total-cost`, and `UniformCostPlanner`
+(`"ucs"`) is cost-optimal — where `BFSPlanner` minimizes the number of actions,
+`"ucs"` minimizes total cost.
+
 ```python
 >>> import pddlpy
 >>> from pddlpy.planning import get
@@ -150,14 +156,14 @@ There are wonderful material at the the University of Edinburgh:
 
 ### Future development ###
 
-* Action costs (`total-cost`) and cost-aware search.
 * Durative actions (recover duration tags into the object model).
 * Heuristic improvements for the reference planners.
 
 Done recently: case-insensitive keywords, `:requirements` capture/enforcement,
-a planner interface with BFS/A*/GBFS reference planners, numeric fluents
-(`:functions`, numeric preconditions/effects), and a measured test suite with
-full coverage of the object model and planning layer.
+a planner interface with BFS/A*/GBFS/UCS reference planners, numeric fluents
+(`:functions`, numeric preconditions/effects), action costs (`total-cost` +
+cost-aware search), and a measured test suite with full coverage of the object
+model and planning layer.
 
 ### Advanced ###
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The orginal grammar file was authored by Zeyn Saigol from University of Birmingh
 
 ### NOTICE ###
 
-While the parser does recognize durations you cannot recover these tags from Python.
+Durative actions are now recovered into the object model (see _Planning API_).
+The reference planners, however, are non-temporal and do not solve durative
+domains — that is documented as out of scope for this round.
 
 ### What this project is not? ###
 
@@ -120,6 +122,13 @@ Action costs (`:action-costs`, `(increase (total-cost) ...)`, `(:metric minimize
 (`"ucs"`) is cost-optimal — where `BFSPlanner` minimizes the number of actions,
 `"ucs"` minimizes total cost.
 
+Durative actions (`:durative-actions`) are recovered into a `DurativeAction`
+type with time-tagged conditions (`at start` / `over all` / `at end`) and
+effects (`at start` / `at end`) plus a duration. `DomainProblem.durative_operators()`
+and `ground_durative_operator(name)` expose them. The reference planners are
+non-temporal, so they do not solve durative domains — this is documented as out
+of scope for now.
+
 ```python
 >>> import pddlpy
 >>> from pddlpy.planning import get
@@ -156,14 +165,15 @@ There are wonderful material at the the University of Edinburgh:
 
 ### Future development ###
 
-* Durative actions (recover duration tags into the object model).
+* A temporal planner that solves durative-action domains.
 * Heuristic improvements for the reference planners.
+* ADL (conditional effects, quantifiers) and a full and/or/not precondition tree.
 
 Done recently: case-insensitive keywords, `:requirements` capture/enforcement,
 a planner interface with BFS/A*/GBFS/UCS reference planners, numeric fluents
 (`:functions`, numeric preconditions/effects), action costs (`total-cost` +
-cost-aware search), and a measured test suite with full coverage of the object
-model and planning layer.
+cost-aware search), durative-action recovery into the object model, and a
+measured test suite with full coverage of the object model and planning layer.
 
 ### Advanced ###
 

--- a/TODO.md
+++ b/TODO.md
@@ -89,8 +89,12 @@ numbers link to GitHub. Do not start a later phase until the prior phase's tests
       fluent valuation; BFS/A*/GBFS solve the numeric-transport domain. 100% coverage.*
 
 ## Phase 3 — Action costs
-- [ ] `total-cost` handling; `Plan` carries cost.
-- [ ] Cost-aware search in the reference planner.
+- [x] `total-cost` handling; `Plan` carries cost. *`:action-costs`/`:numeric-fluents` added to the
+      grammar; `(:metric ...)` captured (`DomainProblem.metric()`); `Plan.cost` = accumulated
+      `total-cost` (`costs.action_cost`/`plan_cost`, `TOTAL_COST`).*
+- [x] Cost-aware search in the reference planner. *`UniformCostPlanner` ("ucs") is cost-optimal;
+      on the travel domain UCS picks the cheaper 2-hop route (cost 2) vs BFS's 1-hop (cost 5).
+      100% coverage.*
 
 ## Phase 4 — Durative actions  *(#23)*
 - [ ] **Complete duration-tag recovery** — grammar parses durative actions but Python recovery

--- a/TODO.md
+++ b/TODO.md
@@ -97,10 +97,15 @@ numbers link to GitHub. Do not start a later phase until the prior phase's tests
       100% coverage.*
 
 ## Phase 4 — Durative actions  *(#23)*
-- [ ] **Complete duration-tag recovery** — grammar parses durative actions but Python recovery
-      is incomplete (the known issue in CLAUDE.md).
-- [ ] **`DurativeAction` type** — time-tagged conditions/effects (`at start / over all / at end`).
-- [ ] Decide temporal state representation; temporal-capable planner (or document non-coverage).
+- [x] **Complete duration-tag recovery** — grammar parses durative actions but Python recovery
+      is incomplete (the known issue in CLAUDE.md). *Fixed: durative actions no longer crash the
+      listener; duration recovered (`DurativeAction.duration`). Resolves #23/#27.*
+- [x] **`DurativeAction` type** — time-tagged conditions/effects (`at start / over all / at end`).
+      *`DurativeAction` with `condition_pos/neg` (start/over/end) and `effect_pos/neg` (start/end);
+      `DomainProblem.durative_operators()` + `ground_durative_operator()`. 100% coverage.*
+- [x] Decide temporal state representation; temporal-capable planner (or document non-coverage).
+      *Documented non-coverage: the reference planners are non-temporal and do not solve durative
+      domains (PRD §4/§8). The object model fully recovers durative actions.*
 
 ---
 

--- a/pddl.g4
+++ b/pddl.g4
@@ -506,6 +506,8 @@ REQUIRE_KEY
     | ':quantified-preconditions'
     | ':conditional-effects'
     | ':fluents'
+    | ':numeric-fluents'
+    | ':action-costs'
     | ':adl'
     | ':durative-actions'
     | ':derived-predicates'

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -462,6 +462,12 @@ class ProblemListener(pddlListener):
         self.goals = []
         self.scopes = []
         self.init_numeric = {}
+        self.metric = None
+
+    def enterMetricSpec(self, ctx):
+        # Capture the optimization metric, e.g. ('minimize', '(total-cost)').
+        self.metric = (ctx.optimization().getText().lower(),
+                       ctx.metricFExp().getText())
 
     def enterInit(self, ctx):
         self.scopes.append(Scope())
@@ -588,6 +594,13 @@ class DomainProblem():
         initial numeric value, e.g. {('fuel', 'truck'): 100.0}.
         """
         return dict(self.problem.init_numeric)
+
+    def metric(self):
+        """Returns the optimization metric as ``(optimization, expr_text)``,
+        e.g. ``('minimize', '(total-cost)')``, or ``None`` if the problem
+        declares no metric.
+        """
+        return self.problem.metric
 
     def ground_operator(self, op_name):
         """Returns an interator of Operator instances. Each item of the iterator

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -274,15 +274,68 @@ class Operator():
                          self.effect_pos, self.effect_neg)
 
 
+class DurativeAction():
+    """Represents a durative action (#23). Distinct from Operator: conditions
+    are time-tagged 'at start' / 'over all' / 'at end', and effects 'at start'
+    / 'at end'. Can be grounded or ungrounded.
+
+    Attributes:
+        operator_name -- the name of the durative action.
+        variable_list -- {var: value} bindings (value None when ungrounded).
+        duration -- the action duration as a float (from (= ?duration N)),
+                    or None if not a simple numeric constraint.
+        condition_pos / condition_neg -- dicts keyed by 'start'/'over'/'end',
+                    each a set of (grounded: tuple / ungrounded: Atom) condition
+                    atoms.
+        effect_pos / effect_neg -- dicts keyed by 'start'/'end', each a set of
+                    effect atoms to add / delete at that time point.
+    """
+    CONDITION_TIMES = ('start', 'over', 'end')
+    EFFECT_TIMES = ('start', 'end')
+
+    def __init__(self, name):
+        self.operator_name = name
+        self.variable_list = {}
+        self.duration = None
+        self.condition_pos = {t: set() for t in self.CONDITION_TIMES}
+        self.condition_neg = {t: set() for t in self.CONDITION_TIMES}
+        self.effect_pos = {t: set() for t in self.EFFECT_TIMES}
+        self.effect_neg = {t: set() for t in self.EFFECT_TIMES}
+
+    def ground(self, varvals):
+        """Return a grounded copy with variables substituted and atoms turned
+        into tuples."""
+        g = DurativeAction(self.operator_name)
+        g.variable_list = dict(varvals)
+        g.duration = self.duration
+        for t in self.CONDITION_TIMES:
+            g.condition_pos[t] = set(a.ground(varvals) for a in self.condition_pos[t])
+            g.condition_neg[t] = set(a.ground(varvals) for a in self.condition_neg[t])
+        for t in self.EFFECT_TIMES:
+            g.effect_pos[t] = set(a.ground(varvals) for a in self.effect_pos[t])
+            g.effect_neg[t] = set(a.ground(varvals) for a in self.effect_neg[t])
+        return g
+
+    def __str__(self):
+        return ("Durative Action: %s\n\tVariables: %s\n\tDuration: %s\n\t"
+                "Conditions (+): %s\n\tConditions (-): %s\n\t"
+                "Effects (+): %s\n\tEffects (-): %s\n") % (
+            self.operator_name, self.variable_list, self.duration,
+            self.condition_pos, self.condition_neg,
+            self.effect_pos, self.effect_neg)
+
+
 class DomainListener(pddlListener):
     def __init__(self):
         self.typesdef = False
         self.objects = {}
         self.operators = {}
+        self.durative_operators = {}
         self.scopes = []
         self.negativescopes = []
         self.requirements = set()
         self.functions = {}
+        self._datimes = []      # stack of current 'start'/'over'/'end' tags
 
     def enterRequireDef(self, ctx):
         # Capture declared :requirements (e.g. ':strips', ':typing').
@@ -319,6 +372,50 @@ class DomainListener(pddlListener):
     def exitActionDef(self, ctx):
         action = self.scopes.pop()
         self.operators[action.operator_name] = action
+
+    # -- durative actions (#23) ------------------------------------------
+    def enterDurativeActionDef(self, ctx):
+        self.scopes.append(DurativeAction(ctx.actionSymbol().getText()))
+
+    def exitDurativeActionDef(self, ctx):
+        action = self.scopes.pop()
+        self.durative_operators[action.operator_name] = action
+
+    def enterSimpleDurationConstraint(self, ctx):
+        # Capture (= ?duration N) / (<= ?duration N) etc. when N is a literal.
+        durval = ctx.durValue()
+        if durval is not None and durval.NUMBER() is not None:
+            da = self.scopes[-1]
+            if isinstance(da, DurativeAction):
+                da.duration = float(durval.NUMBER().getText())
+
+    def enterTimedGD(self, ctx):
+        # (at start|end goalDesc) or (over all goalDesc): collect the condition
+        # atoms into a fresh Scope tagged with the time point.
+        if ctx.timeSpecifier() is not None:
+            self._datimes.append(ctx.timeSpecifier().getText().lower())
+        else:
+            self._datimes.append('over')
+        self.scopes.append(Scope())
+
+    def exitTimedGD(self, ctx):
+        scope = self.scopes.pop()
+        time = self._datimes.pop()
+        da = self.scopes[-1]
+        da.condition_pos[time] |= set(scope.atoms)
+        da.condition_neg[time] |= set(scope.negatoms)
+
+    def enterTimedEffect(self, ctx):
+        # (at start|end cEffect): collect the effect atoms into a fresh Scope.
+        self._datimes.append(ctx.timeSpecifier().getText().lower())
+        self.scopes.append(Scope())
+
+    def exitTimedEffect(self, ctx):
+        scope = self.scopes.pop()
+        time = self._datimes.pop()
+        da = self.scopes[-1]
+        da.effect_pos[time] |= set(scope.atoms)
+        da.effect_neg[time] |= set(scope.negatoms)
 
     def enterPredicatesDef(self, ctx):
         self.scopes.append(Operator(None))
@@ -571,10 +668,17 @@ class DomainProblem():
         self.vargroundspace = {}
 
     def operators(self):
-        """Returns an iterator of the names of the actions defined in
-        the domain file.
+        """Returns an iterator of the names of the (instantaneous) actions
+        defined in the domain file. Durative actions are listed separately by
+        durative_operators().
         """
         return self.domain.operators.keys()
+
+    def durative_operators(self):
+        """Returns an iterator of the names of the durative actions (#23)
+        defined in the domain file.
+        """
+        return self.domain.durative_operators.keys()
 
     def requirements(self):
         """Returns the set of :requirements keywords declared in the domain
@@ -623,6 +727,13 @@ class DomainProblem():
             gop.precondition_num = [ c.ground( st ) for c in op.precondition_num ]
             gop.effect_num = [ e.ground( st ) for e in op.effect_num ]
             yield gop
+
+    def ground_durative_operator(self, op_name):
+        """Returns an iterator of grounded DurativeAction instances (#23)."""
+        op = self.domain.durative_operators[op_name]
+        self._set_operator_groundspace( op_name, op.variable_list.items() )
+        for ground in self._instantiate( op_name ):
+            yield op.ground( dict(ground) )
 
     def _typesymbols(self, t):
         return ( k for k,v in self.worldobjects().items() if v == t )

--- a/pddlpy/planning/__init__.py
+++ b/pddlpy/planning/__init__.py
@@ -14,7 +14,14 @@ from .base import (
     validate_requirements,
 )
 from .registry import registry, register, get
-from .search import BFSPlanner, AStarPlanner, GBFSPlanner, STRIPS_CAPABILITIES
+from .search import (
+    BFSPlanner,
+    AStarPlanner,
+    GBFSPlanner,
+    UniformCostPlanner,
+    STRIPS_CAPABILITIES,
+)
+from .costs import action_cost, plan_cost, TOTAL_COST
 
 __all__ = [
     "State",
@@ -31,5 +38,9 @@ __all__ = [
     "BFSPlanner",
     "AStarPlanner",
     "GBFSPlanner",
+    "UniformCostPlanner",
     "STRIPS_CAPABILITIES",
+    "action_cost",
+    "plan_cost",
+    "TOTAL_COST",
 ]

--- a/pddlpy/planning/costs.py
+++ b/pddlpy/planning/costs.py
@@ -1,0 +1,35 @@
+"""Action-cost helpers (Phase 3).
+
+PDDL action costs are modeled as ``(increase (total-cost) <expr>)`` effects,
+typically minimized via ``(:metric minimize (total-cost))``. ``total-cost`` is
+just a numeric fluent (Phase 2), so the cost machinery is thin: read the
+``total-cost`` increases for per-step cost, and read the accumulated
+``total-cost`` fluent for the final plan cost.
+"""
+
+#: The reserved cost fluent head.
+TOTAL_COST = ("total-cost",)
+
+
+def action_cost(operator, state):
+    """The cost of applying ``operator`` in ``state``.
+
+    Sums the ``(increase (total-cost) expr)`` effects (each ``expr`` evaluated
+    in the current state). Actions with no ``total-cost`` effect cost 1.0, so
+    cost-aware search degrades gracefully to unit cost.
+    """
+    total = 0.0
+    found = False
+    for eff in operator.effect_num:
+        if eff.head.head == TOTAL_COST and eff.op == "increase":
+            total += eff.expr.value(state.fluents)
+            found = True
+    return total if found else 1.0
+
+
+def plan_cost(goal_state, actions):
+    """The cost of a found plan: the accumulated ``total-cost`` if the domain
+    tracks it, otherwise the number of actions."""
+    if TOTAL_COST in goal_state.fluents:
+        return goal_state.fluents[TOTAL_COST]
+    return len(actions)

--- a/pddlpy/planning/search.py
+++ b/pddlpy/planning/search.py
@@ -1,12 +1,14 @@
 """Blind- and heuristic-search reference planners over STRIPS.
 
 These prove the ``Planner`` contract; they are not performance entrants
-(PRD §4). All three reuse the shared ``GroundedTask`` successor function.
+(PRD §4). All reuse the shared ``GroundedTask`` successor function.
 
-* ``BFSPlanner``   — breadth-first; optimal for unit-cost STRIPS.
-* ``AStarPlanner`` — A* with the goal-count heuristic; optimal & admissible
-  for unit costs.
-* ``GBFSPlanner``  — greedy best-first; fast but not optimal.
+* ``BFSPlanner``        — breadth-first; optimal for unit-cost STRIPS.
+* ``AStarPlanner``      — A* with the goal-count heuristic; optimal &
+  admissible for unit costs.
+* ``GBFSPlanner``       — greedy best-first; fast but not optimal.
+* ``UniformCostPlanner`` — Dijkstra over action costs; cost-optimal for
+  action-cost domains (#3).
 """
 import heapq
 import itertools
@@ -15,13 +17,15 @@ from collections import deque
 from .base import Planner
 from .state import Plan, atom_tuple
 from .registry import register
+from .costs import action_cost, plan_cost
 
-#: Requirements the reference planners can handle. Numeric fluents (#11) are
-#: supported because State evaluates numeric preconditions/effects during
-#: successor generation; the goal-count heuristic ignores them (still
-#: admissible for the symbolic goal).
+#: Requirements the reference planners can handle. Numeric fluents (#11) and
+#: action costs (#3) are supported because State evaluates numeric
+#: preconditions/effects during successor generation; the goal-count heuristic
+#: ignores them (still admissible for the symbolic goal).
 STRIPS_CAPABILITIES = frozenset(
-    {":strips", ":typing", ":negative-preconditions", ":equality", ":fluents"}
+    {":strips", ":typing", ":negative-preconditions", ":equality",
+     ":fluents", ":numeric-fluents", ":action-costs"}
 )
 
 
@@ -62,19 +66,26 @@ class BFSPlanner(Planner):
                     continue
                 came_from[succ] = (state, action)
                 if task.is_goal(succ):
-                    return Plan(_reconstruct(came_from, succ))
+                    actions = _reconstruct(came_from, succ)
+                    return Plan(actions, cost=plan_cost(succ, actions))
                 visited.add(succ)
                 frontier.append(succ)
         return None
 
 
 class _BestFirstPlanner(Planner):
-    """Shared best-first core; subclasses define the node priority."""
+    """Shared best-first core; subclasses define the node priority and the
+    per-step cost."""
 
     capabilities = STRIPS_CAPABILITIES
 
     def _priority(self, g, h):
         raise NotImplementedError  # pragma: no cover - abstract
+
+    def _step_cost(self, action, state):
+        """Cost of one transition. Unit by default; cost-aware planners
+        override."""
+        return 1
 
     def solve(self, domainproblem):
         task = self.prepare(domainproblem)
@@ -88,11 +99,12 @@ class _BestFirstPlanner(Planner):
         while frontier:
             _, g, _, state = heapq.heappop(frontier)
             if task.is_goal(state):
-                return Plan(_reconstruct(came_from, state))
+                actions = _reconstruct(came_from, state)
+                return Plan(actions, cost=plan_cost(state, actions))
             if g > best_g.get(state, g):
                 continue  # pragma: no cover - stale heap entry (lazy deletion)
             for action, succ in task.successors(state):
-                ng = g + 1
+                ng = g + self._step_cost(action, state)
                 if ng < best_g.get(succ, ng + 1):
                     best_g[succ] = ng
                     came_from[succ] = (state, action)
@@ -104,7 +116,7 @@ class _BestFirstPlanner(Planner):
 
 
 class AStarPlanner(_BestFirstPlanner):
-    """A* with the goal-count heuristic (f = g + h)."""
+    """A* with the goal-count heuristic (f = g + h), unit step cost."""
 
     def _priority(self, g, h):
         return g + h
@@ -117,6 +129,19 @@ class GBFSPlanner(_BestFirstPlanner):
         return h
 
 
+class UniformCostPlanner(_BestFirstPlanner):
+    """Dijkstra over action costs (f = g, h ignored). Cost-optimal for
+    action-cost domains (#3); falls back to unit cost when a domain declares
+    none."""
+
+    def _priority(self, g, h):
+        return g
+
+    def _step_cost(self, action, state):
+        return action_cost(action, state)
+
+
 register("bfs", BFSPlanner)
 register("astar", AStarPlanner)
 register("gbfs", GBFSPlanner)
+register("ucs", UniformCostPlanner)

--- a/tests/corpus/durative-action-domain.pddl
+++ b/tests/corpus/durative-action-domain.pddl
@@ -1,9 +1,19 @@
+;; Durative-action domain (#23): a move with time-tagged conditions and
+;; effects ('at start' / 'over all' / 'at end').
 (define (domain da)
- (:requirements :strips :typing :durative-actions)
- (:types loc)
- (:predicates (at ?l - loc) (visited ?l - loc))
- (:durative-action go
-   :parameters (?from - loc ?to - loc)
-   :duration (= ?duration 5)
-   :condition (at start (at ?from))
-   :effect (and (at start (not (at ?from))) (at end (at ?to)) (at end (visited ?to)))))
+  (:requirements :strips :typing :durative-actions)
+  (:types loc)
+  (:predicates
+    (at ?l - loc)
+    (visited ?l - loc)
+    (road ?a - loc ?b - loc))
+
+  (:durative-action go
+    :parameters (?from - loc ?to - loc)
+    :duration (= ?duration 5)
+    :condition (and (at start (at ?from))
+                    (over all (road ?from ?to))
+                    (at end (road ?from ?to)))
+    :effect (and (at start (not (at ?from)))
+                 (at end (at ?to))
+                 (at end (visited ?to)))))

--- a/tests/corpus/durative-action-problem.pddl
+++ b/tests/corpus/durative-action-problem.pddl
@@ -1,3 +1,5 @@
-(define (problem dap) (:domain da)
- (:objects a b - loc)
- (:init (at a)) (:goal (visited b)))
+(define (problem dap)
+  (:domain da)
+  (:objects a b - loc)
+  (:init (at a) (road a b))
+  (:goal (visited b)))

--- a/tests/corpus/travel-domain.pddl
+++ b/tests/corpus/travel-domain.pddl
@@ -1,0 +1,19 @@
+;; Action-costs domain: moving between connected places accrues total-cost
+;; equal to the distance travelled. A cost-aware planner should prefer the
+;; cheaper multi-hop route over a single expensive hop.
+(define (domain travel)
+  (:requirements :strips :typing :action-costs)
+  (:types place)
+  (:predicates
+    (at ?p - place)
+    (connected ?a - place ?b - place))
+  (:functions
+    (total-cost)
+    (distance ?a - place ?b - place))
+
+  (:action move
+    :parameters (?from - place ?to - place)
+    :precondition (and (at ?from) (connected ?from ?to))
+    :effect (and (not (at ?from))
+                 (at ?to)
+                 (increase (total-cost) (distance ?from ?to)))))

--- a/tests/corpus/travel-problem.pddl
+++ b/tests/corpus/travel-problem.pddl
@@ -1,0 +1,12 @@
+(define (problem travel-01)
+  (:domain travel)
+  (:objects a b c - place)
+  (:init
+    (at a)
+    (connected a b) (connected b c) (connected a c)
+    (= (total-cost) 0)
+    (= (distance a b) 1)
+    (= (distance b c) 1)
+    (= (distance a c) 5))
+  (:goal (at c))
+  (:metric minimize (total-cost)))

--- a/tests/test_action_costs.py
+++ b/tests/test_action_costs.py
@@ -1,0 +1,94 @@
+"""#3 action costs: metric capture, action_cost/plan_cost, cost-aware search."""
+import os
+
+from pddlpy import DomainProblem
+from pddlpy.planning import (
+    State,
+    GroundedTask,
+    BFSPlanner,
+    AStarPlanner,
+    UniformCostPlanner,
+    action_cost,
+    plan_cost,
+    TOTAL_COST,
+    get,
+    registry,
+)
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _travel():
+    return DomainProblem(
+        os.path.join(CORPUS, "travel-domain.pddl"),
+        os.path.join(CORPUS, "travel-problem.pddl"),
+    )
+
+
+def _move(dp, frm, to):
+    return next(
+        g for g in dp.ground_operator("move")
+        if g.variable_list == {"?from": frm, "?to": to}
+    )
+
+
+def test_metric_captured():
+    assert _travel().metric() == ("minimize", "(total-cost)")
+
+
+def test_action_cost_reads_total_cost_increase():
+    dp = _travel()
+    state = State.from_problem(dp)
+    assert action_cost(_move(dp, "a", "b"), state) == 1.0
+    assert action_cost(_move(dp, "a", "c"), state) == 5.0
+
+
+def test_action_cost_defaults_to_one_without_total_cost():
+    # blocksworld actions have no total-cost effect -> unit cost.
+    dp = DomainProblem(
+        os.path.join(CORPUS, "blocksworld-domain.pddl"),
+        os.path.join(CORPUS, "blocksworld-problem.pddl"),
+    )
+    state = State.from_problem(dp)
+    op = next(dp.ground_operator("pick-up"))
+    assert action_cost(op, state) == 1.0
+
+
+def test_plan_cost_helper():
+    goal_with_cost = State([("at", "c")], {TOTAL_COST: 7.0})
+    assert plan_cost(goal_with_cost, [1, 2]) == 7.0
+    goal_without = State([("at", "c")])
+    assert plan_cost(goal_without, [1, 2, 3]) == 3
+
+
+def test_ucs_is_cost_optimal():
+    dp = _travel()
+    plan = UniformCostPlanner().solve(dp)
+    route = [b["?to"] for _, b in plan.action_names()]
+    assert route == ["b", "c"]   # cheaper 2-hop route
+    assert plan.cost == 2.0
+
+
+def test_bfs_minimizes_actions_not_cost():
+    dp = _travel()
+    plan = BFSPlanner().solve(dp)
+    route = [b["?to"] for _, b in plan.action_names()]
+    assert route == ["c"]        # single hop, fewest actions
+    assert plan.cost == 5.0      # but its true total-cost is higher
+
+
+def test_ucs_registered():
+    assert "ucs" in registry.names()
+    assert isinstance(get("ucs"), UniformCostPlanner)
+
+
+def test_ucs_plan_is_valid():
+    dp = _travel()
+    plan = UniformCostPlanner().solve(dp)
+    task = GroundedTask(dp)
+    state = task.initial
+    for action in plan:
+        assert state.applicable(action)
+        state = state.apply(action)
+    assert task.is_goal(state)
+    assert state.fluents[TOTAL_COST] == 2.0

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -29,6 +29,7 @@ BENCHMARKS = [
         },
     ),
     ("numeric-transport", {"drive"}),
+    ("travel", {"move"}),
 ]
 
 

--- a/tests/test_durative.py
+++ b/tests/test_durative.py
@@ -1,0 +1,68 @@
+"""#23 durative actions: parsing into the DurativeAction model, time-tagged
+conditions/effects, grounding, and __str__.
+
+Note: the reference planners do not cover temporal planning (PRD §4/§8
+documents this as out of scope); these tests exercise the object model.
+"""
+import os
+
+from pddlpy import DomainProblem
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _da():
+    return DomainProblem(
+        os.path.join(CORPUS, "durative-action-domain.pddl"),
+        os.path.join(CORPUS, "durative-action-problem.pddl"),
+    )
+
+
+def test_durative_operator_listed_separately():
+    dp = _da()
+    assert set(dp.durative_operators()) == {"go"}
+    assert set(dp.operators()) == set()  # not an instantaneous action
+
+
+def test_duration_and_time_tagged_conditions():
+    dp = _da()
+    go = dp.domain.durative_operators["go"]
+    assert go.duration == 5.0
+
+    def tuples(atoms):
+        return {tuple(a.predicate) for a in atoms}
+
+    assert tuples(go.condition_pos["start"]) == {("at", "?from")}
+    assert tuples(go.condition_pos["over"]) == {("road", "?from", "?to")}
+    assert tuples(go.condition_pos["end"]) == {("road", "?from", "?to")}
+
+
+def test_time_tagged_effects():
+    dp = _da()
+    go = dp.domain.durative_operators["go"]
+
+    def tuples(atoms):
+        return {tuple(a.predicate) for a in atoms}
+
+    assert tuples(go.effect_neg["start"]) == {("at", "?from")}
+    assert tuples(go.effect_pos["end"]) == {("at", "?to"), ("visited", "?to")}
+
+
+def test_grounding_durative():
+    dp = _da()
+    grounded = list(dp.ground_durative_operator("go"))
+    go_ab = next(
+        g for g in grounded if g.variable_list == {"?from": "a", "?to": "b"}
+    )
+    assert go_ab.duration == 5.0
+    assert go_ab.condition_pos["start"] == {("at", "a")}
+    assert go_ab.condition_pos["over"] == {("road", "a", "b")}
+    assert go_ab.effect_pos["end"] == {("at", "b"), ("visited", "b")}
+    assert go_ab.effect_neg["start"] == {("at", "a")}
+
+
+def test_durative_str():
+    dp = _da()
+    text = str(dp.domain.durative_operators["go"])
+    assert "Durative Action: go" in text
+    assert "Duration: 5.0" in text

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -8,8 +8,6 @@
 """
 import os
 
-import pytest
-
 from pddlpy import DomainProblem
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
@@ -25,16 +23,13 @@ def test_no_python2_builtin_import():
     assert "__builtin__" not in dir(pddl)
 
 
-@pytest.mark.xfail(
-    reason="#27/#23: durative-action recovery incomplete; no enterDurativeActionDef "
-    "scope is pushed, so enterTypedVariableList raises IndexError. Deferred to Phase 4.",
-    raises=IndexError,
-    strict=True,
-)
 def test_durative_action_parses():
+    # #27/#23: fixed in Phase 4. Durative actions used to crash the listener
+    # with IndexError; they now parse into the DurativeAction model and are
+    # listed under durative_operators() (not operators()).
     dp = DomainProblem(
         os.path.join(CORPUS, "durative-action-domain.pddl"),
         os.path.join(CORPUS, "durative-action-problem.pddl"),
     )
-    assert "go" in set(dp.operators())
+    assert "go" in set(dp.durative_operators())
     assert len(dp.goals()) > 0


### PR DESCRIPTION
Phase 3 of the PRD roadmap: action costs and cost-aware search. **Stacked on Phase 2** (`phase-2-numeric`) — review/merge that first.

## Grammar / model
- Added `:action-costs` and `:numeric-fluents` to `REQUIRE_KEY` (regenerated parser) so cost domains parse.
- Capture `(:metric minimize|maximize <expr>)` in `ProblemListener`; expose `DomainProblem.metric()`.

## Planning layer
- `costs.py`: `TOTAL_COST`, `action_cost(op, state)` (sum of `(increase (total-cost) expr)`, default 1.0), `plan_cost(goal_state, actions)` (accumulated `total-cost`, else action count).
- `_BestFirstPlanner` gains an overridable per-step cost.
- **`UniformCostPlanner`** (`"ucs"`) — Dijkstra over action costs, cost-optimal (falls back to unit cost when a domain declares none).
- `Plan.cost` now reflects the accumulated `total-cost` for every planner.

## Demonstration (travel domain)
`a→b→c` costs 2 (distances 1+1); `a→c` costs 5 (one hop).
- `BFSPlanner` minimizes **actions** → `a→c`, `cost=5`.
- `UniformCostPlanner` minimizes **cost** → `a→b→c`, `cost=2`.

## Tests
- New `travel` action-costs corpus pair (added to the parse-guard).
- `tests/test_action_costs.py`: metric capture, `action_cost`/`plan_cost`, UCS cost-optimality vs BFS, plan validity.
- **100% line coverage** maintained (99 passed, 1 xfail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)