### PR TITLE
Phase 4 — Durative actions (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The orginal grammar file was authored by Zeyn Saigol from University of Birmingh
 
 ### NOTICE ###
 
-While the parser does recognize durations you cannot recover these tags from Python.
+Durative actions are now recovered into the object model (see _Planning API_).
+The reference planners, however, are non-temporal and do not solve durative
+domains — that is documented as out of scope for this round.
 
 ### What this project is not? ###
 
@@ -120,6 +122,13 @@ Action costs (`:action-costs`, `(increase (total-cost) ...)`, `(:metric minimize
 (`"ucs"`) is cost-optimal — where `BFSPlanner` minimizes the number of actions,
 `"ucs"` minimizes total cost.
 
+Durative actions (`:durative-actions`) are recovered into a `DurativeAction`
+type with time-tagged conditions (`at start` / `over all` / `at end`) and
+effects (`at start` / `at end`) plus a duration. `DomainProblem.durative_operators()`
+and `ground_durative_operator(name)` expose them. The reference planners are
+non-temporal, so they do not solve durative domains — this is documented as out
+of scope for now.
+
 ```python
 >>> import pddlpy
 >>> from pddlpy.planning import get
@@ -156,14 +165,15 @@ There are wonderful material at the the University of Edinburgh:
 
 ### Future development ###
 
-* Durative actions (recover duration tags into the object model).
+* A temporal planner that solves durative-action domains.
 * Heuristic improvements for the reference planners.
+* ADL (conditional effects, quantifiers) and a full and/or/not precondition tree.
 
 Done recently: case-insensitive keywords, `:requirements` capture/enforcement,
 a planner interface with BFS/A*/GBFS/UCS reference planners, numeric fluents
 (`:functions`, numeric preconditions/effects), action costs (`total-cost` +
-cost-aware search), and a measured test suite with full coverage of the object
-model and planning layer.
+cost-aware search), durative-action recovery into the object model, and a
+measured test suite with full coverage of the object model and planning layer.
 
 ### Advanced ###
 

--- a/TODO.md
+++ b/TODO.md
@@ -97,10 +97,15 @@ numbers link to GitHub. Do not start a later phase until the prior phase's tests
       100% coverage.*
 
 ## Phase 4 — Durative actions  *(#23)*
-- [ ] **Complete duration-tag recovery** — grammar parses durative actions but Python recovery
-      is incomplete (the known issue in CLAUDE.md).
-- [ ] **`DurativeAction` type** — time-tagged conditions/effects (`at start / over all / at end`).
-- [ ] Decide temporal state representation; temporal-capable planner (or document non-coverage).
+- [x] **Complete duration-tag recovery** — grammar parses durative actions but Python recovery
+      is incomplete (the known issue in CLAUDE.md). *Fixed: durative actions no longer crash the
+      listener; duration recovered (`DurativeAction.duration`). Resolves #23/#27.*
+- [x] **`DurativeAction` type** — time-tagged conditions/effects (`at start / over all / at end`).
+      *`DurativeAction` with `condition_pos/neg` (start/over/end) and `effect_pos/neg` (start/end);
+      `DomainProblem.durative_operators()` + `ground_durative_operator()`. 100% coverage.*
+- [x] Decide temporal state representation; temporal-capable planner (or document non-coverage).
+      *Documented non-coverage: the reference planners are non-temporal and do not solve durative
+      domains (PRD §4/§8). The object model fully recovers durative actions.*
 
 ---
 

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -274,15 +274,68 @@ class Operator():
                          self.effect_pos, self.effect_neg)
 
 
+class DurativeAction():
+    """Represents a durative action (#23). Distinct from Operator: conditions
+    are time-tagged 'at start' / 'over all' / 'at end', and effects 'at start'
+    / 'at end'. Can be grounded or ungrounded.
+
+    Attributes:
+        operator_name -- the name of the durative action.
+        variable_list -- {var: value} bindings (value None when ungrounded).
+        duration -- the action duration as a float (from (= ?duration N)),
+                    or None if not a simple numeric constraint.
+        condition_pos / condition_neg -- dicts keyed by 'start'/'over'/'end',
+                    each a set of (grounded: tuple / ungrounded: Atom) condition
+                    atoms.
+        effect_pos / effect_neg -- dicts keyed by 'start'/'end', each a set of
+                    effect atoms to add / delete at that time point.
+    """
+    CONDITION_TIMES = ('start', 'over', 'end')
+    EFFECT_TIMES = ('start', 'end')
+
+    def __init__(self, name):
+        self.operator_name = name
+        self.variable_list = {}
+        self.duration = None
+        self.condition_pos = {t: set() for t in self.CONDITION_TIMES}
+        self.condition_neg = {t: set() for t in self.CONDITION_TIMES}
+        self.effect_pos = {t: set() for t in self.EFFECT_TIMES}
+        self.effect_neg = {t: set() for t in self.EFFECT_TIMES}
+
+    def ground(self, varvals):
+        """Return a grounded copy with variables substituted and atoms turned
+        into tuples."""
+        g = DurativeAction(self.operator_name)
+        g.variable_list = dict(varvals)
+        g.duration = self.duration
+        for t in self.CONDITION_TIMES:
+            g.condition_pos[t] = set(a.ground(varvals) for a in self.condition_pos[t])
+            g.condition_neg[t] = set(a.ground(varvals) for a in self.condition_neg[t])
+        for t in self.EFFECT_TIMES:
+            g.effect_pos[t] = set(a.ground(varvals) for a in self.effect_pos[t])
+            g.effect_neg[t] = set(a.ground(varvals) for a in self.effect_neg[t])
+        return g
+
+    def __str__(self):
+        return ("Durative Action: %s\n\tVariables: %s\n\tDuration: %s\n\t"
+                "Conditions (+): %s\n\tConditions (-): %s\n\t"
+                "Effects (+): %s\n\tEffects (-): %s\n") % (
+            self.operator_name, self.variable_list, self.duration,
+            self.condition_pos, self.condition_neg,
+            self.effect_pos, self.effect_neg)
+
+
 class DomainListener(pddlListener):
     def __init__(self):
         self.typesdef = False
         self.objects = {}
         self.operators = {}
+        self.durative_operators = {}
         self.scopes = []
         self.negativescopes = []
         self.requirements = set()
         self.functions = {}
+        self._datimes = []      # stack of current 'start'/'over'/'end' tags
 
     def enterRequireDef(self, ctx):
         # Capture declared :requirements (e.g. ':strips', ':typing').
@@ -319,6 +372,50 @@ class DomainListener(pddlListener):
     def exitActionDef(self, ctx):
         action = self.scopes.pop()
         self.operators[action.operator_name] = action
+
+    # -- durative actions (#23) ------------------------------------------
+    def enterDurativeActionDef(self, ctx):
+        self.scopes.append(DurativeAction(ctx.actionSymbol().getText()))
+
+    def exitDurativeActionDef(self, ctx):
+        action = self.scopes.pop()
+        self.durative_operators[action.operator_name] = action
+
+    def enterSimpleDurationConstraint(self, ctx):
+        # Capture (= ?duration N) / (<= ?duration N) etc. when N is a literal.
+        durval = ctx.durValue()
+        if durval is not None and durval.NUMBER() is not None:
+            da = self.scopes[-1]
+            if isinstance(da, DurativeAction):
+                da.duration = float(durval.NUMBER().getText())
+
+    def enterTimedGD(self, ctx):
+        # (at start|end goalDesc) or (over all goalDesc): collect the condition
+        # atoms into a fresh Scope tagged with the time point.
+        if ctx.timeSpecifier() is not None:
+            self._datimes.append(ctx.timeSpecifier().getText().lower())
+        else:
+            self._datimes.append('over')
+        self.scopes.append(Scope())
+
+    def exitTimedGD(self, ctx):
+        scope = self.scopes.pop()
+        time = self._datimes.pop()
+        da = self.scopes[-1]
+        da.condition_pos[time] |= set(scope.atoms)
+        da.condition_neg[time] |= set(scope.negatoms)
+
+    def enterTimedEffect(self, ctx):
+        # (at start|end cEffect): collect the effect atoms into a fresh Scope.
+        self._datimes.append(ctx.timeSpecifier().getText().lower())
+        self.scopes.append(Scope())
+
+    def exitTimedEffect(self, ctx):
+        scope = self.scopes.pop()
+        time = self._datimes.pop()
+        da = self.scopes[-1]
+        da.effect_pos[time] |= set(scope.atoms)
+        da.effect_neg[time] |= set(scope.negatoms)
 
     def enterPredicatesDef(self, ctx):
         self.scopes.append(Operator(None))
@@ -571,10 +668,17 @@ class DomainProblem():
         self.vargroundspace = {}
 
     def operators(self):
-        """Returns an iterator of the names of the actions defined in
-        the domain file.
+        """Returns an iterator of the names of the (instantaneous) actions
+        defined in the domain file. Durative actions are listed separately by
+        durative_operators().
         """
         return self.domain.operators.keys()
+
+    def durative_operators(self):
+        """Returns an iterator of the names of the durative actions (#23)
+        defined in the domain file.
+        """
+        return self.domain.durative_operators.keys()
 
     def requirements(self):
         """Returns the set of :requirements keywords declared in the domain
@@ -623,6 +727,13 @@ class DomainProblem():
             gop.precondition_num = [ c.ground( st ) for c in op.precondition_num ]
             gop.effect_num = [ e.ground( st ) for e in op.effect_num ]
             yield gop
+
+    def ground_durative_operator(self, op_name):
+        """Returns an iterator of grounded DurativeAction instances (#23)."""
+        op = self.domain.durative_operators[op_name]
+        self._set_operator_groundspace( op_name, op.variable_list.items() )
+        for ground in self._instantiate( op_name ):
+            yield op.ground( dict(ground) )
 
     def _typesymbols(self, t):
         return ( k for k,v in self.worldobjects().items() if v == t )

--- a/tests/corpus/durative-action-domain.pddl
+++ b/tests/corpus/durative-action-domain.pddl
@@ -1,9 +1,19 @@
+;; Durative-action domain (#23): a move with time-tagged conditions and
+;; effects ('at start' / 'over all' / 'at end').
 (define (domain da)
- (:requirements :strips :typing :durative-actions)
- (:types loc)
- (:predicates (at ?l - loc) (visited ?l - loc))
- (:durative-action go
-   :parameters (?from - loc ?to - loc)
-   :duration (= ?duration 5)
-   :condition (at start (at ?from))
-   :effect (and (at start (not (at ?from))) (at end (at ?to)) (at end (visited ?to)))))
+  (:requirements :strips :typing :durative-actions)
+  (:types loc)
+  (:predicates
+    (at ?l - loc)
+    (visited ?l - loc)
+    (road ?a - loc ?b - loc))
+
+  (:durative-action go
+    :parameters (?from - loc ?to - loc)
+    :duration (= ?duration 5)
+    :condition (and (at start (at ?from))
+                    (over all (road ?from ?to))
+                    (at end (road ?from ?to)))
+    :effect (and (at start (not (at ?from)))
+                 (at end (at ?to))
+                 (at end (visited ?to)))))

--- a/tests/corpus/durative-action-problem.pddl
+++ b/tests/corpus/durative-action-problem.pddl
@@ -1,3 +1,5 @@
-(define (problem dap) (:domain da)
- (:objects a b - loc)
- (:init (at a)) (:goal (visited b)))
+(define (problem dap)
+  (:domain da)
+  (:objects a b - loc)
+  (:init (at a) (road a b))
+  (:goal (visited b)))

--- a/tests/test_durative.py
+++ b/tests/test_durative.py
@@ -1,0 +1,68 @@
+"""#23 durative actions: parsing into the DurativeAction model, time-tagged
+conditions/effects, grounding, and __str__.
+
+Note: the reference planners do not cover temporal planning (PRD §4/§8
+documents this as out of scope); these tests exercise the object model.
+"""
+import os
+
+from pddlpy import DomainProblem
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _da():
+    return DomainProblem(
+        os.path.join(CORPUS, "durative-action-domain.pddl"),
+        os.path.join(CORPUS, "durative-action-problem.pddl"),
+    )
+
+
+def test_durative_operator_listed_separately():
+    dp = _da()
+    assert set(dp.durative_operators()) == {"go"}
+    assert set(dp.operators()) == set()  # not an instantaneous action
+
+
+def test_duration_and_time_tagged_conditions():
+    dp = _da()
+    go = dp.domain.durative_operators["go"]
+    assert go.duration == 5.0
+
+    def tuples(atoms):
+        return {tuple(a.predicate) for a in atoms}
+
+    assert tuples(go.condition_pos["start"]) == {("at", "?from")}
+    assert tuples(go.condition_pos["over"]) == {("road", "?from", "?to")}
+    assert tuples(go.condition_pos["end"]) == {("road", "?from", "?to")}
+
+
+def test_time_tagged_effects():
+    dp = _da()
+    go = dp.domain.durative_operators["go"]
+
+    def tuples(atoms):
+        return {tuple(a.predicate) for a in atoms}
+
+    assert tuples(go.effect_neg["start"]) == {("at", "?from")}
+    assert tuples(go.effect_pos["end"]) == {("at", "?to"), ("visited", "?to")}
+
+
+def test_grounding_durative():
+    dp = _da()
+    grounded = list(dp.ground_durative_operator("go"))
+    go_ab = next(
+        g for g in grounded if g.variable_list == {"?from": "a", "?to": "b"}
+    )
+    assert go_ab.duration == 5.0
+    assert go_ab.condition_pos["start"] == {("at", "a")}
+    assert go_ab.condition_pos["over"] == {("road", "a", "b")}
+    assert go_ab.effect_pos["end"] == {("at", "b"), ("visited", "b")}
+    assert go_ab.effect_neg["start"] == {("at", "a")}
+
+
+def test_durative_str():
+    dp = _da()
+    text = str(dp.domain.durative_operators["go"])
+    assert "Durative Action: go" in text
+    assert "Duration: 5.0" in text

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -8,8 +8,6 @@
 """
 import os
 
-import pytest
-
 from pddlpy import DomainProblem
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
@@ -25,16 +23,13 @@ def test_no_python2_builtin_import():
     assert "__builtin__" not in dir(pddl)
 
 
-@pytest.mark.xfail(
-    reason="#27/#23: durative-action recovery incomplete; no enterDurativeActionDef "
-    "scope is pushed, so enterTypedVariableList raises IndexError. Deferred to Phase 4.",
-    raises=IndexError,
-    strict=True,
-)
 def test_durative_action_parses():
+    # #27/#23: fixed in Phase 4. Durative actions used to crash the listener
+    # with IndexError; they now parse into the DurativeAction model and are
+    # listed under durative_operators() (not operators()).
     dp = DomainProblem(
         os.path.join(CORPUS, "durative-action-domain.pddl"),
         os.path.join(CORPUS, "durative-action-problem.pddl"),
     )
-    assert "go" in set(dp.operators())
+    assert "go" in set(dp.durative_operators())
     assert len(dp.goals()) > 0


### PR DESCRIPTION
Phase 4 of the PRD roadmap: durative actions. **Stacked on Phase 3** (`phase-3-costs`) — review/merge that first. This is the last phase.

## Fixes #23 / #27
Durative-action files used to crash the listener with `IndexError` (no scope pushed for `:durative-action`). They now parse cleanly.

## Object model
- New **`DurativeAction`** type: time-tagged conditions (`at start` / `over all` / `at end`) and effects (`at start` / `at end`), plus a recovered `duration`.
- Listener handlers: `enterDurativeActionDef`, `enterTimedGD` / `enterTimedEffect` (route atoms into time-tagged buckets via the existing Scope/negative-scope machinery), `enterSimpleDurationConstraint` (recover `(= ?duration N)`).
- `DomainProblem.durative_operators()` and `ground_durative_operator(name)`.

## Temporal planning — documented non-coverage
Per PRD §4/§8, the reference planners are **non-temporal** and do not solve durative domains. The object model fully recovers durative actions; a temporal planner is left as future work. README + CLAUDE.md updated accordingly (the old "duration recovery incomplete" known-issue is resolved).

## Tests
- Enriched durative corpus fixture (`over all` + `at end` conditions).
- `tests/test_durative.py` (parse, time-tagged buckets, grounding, `__str__`); the former #23/#27 `xfail` is now a passing test.
- **100% line coverage** maintained (105 passed, 0 xfail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)