### PR TITLE
#74 — Add type hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,16 @@ coverage: pyparser pddlpy/pddl.py
 	@echo "Running tests with coverage..."
 	$(PYTHON) -m pytest --cov=pddlpy --cov-report=term-missing
 
+# Lint with ruff (generated ANTLR files are excluded via pyproject)
+lint:
+	@echo "Linting with ruff..."
+	$(PYTHON) -m ruff check pddlpy tests demo.py
+
+# Type-check with mypy
+typecheck: pyparser pddlpy/pddl.py
+	@echo "Type checking with mypy..."
+	$(PYTHON) -m mypy
+
 # Build distribution with uv
 build: test
 	@echo "Building distribution..."
@@ -99,6 +109,8 @@ help:
 	@echo "  pyparser     - Generate Python parser from grammar"
 	@echo "  test         - Run Python tests"
 	@echo "  coverage     - Run tests with coverage report"
+	@echo "  lint         - Lint with ruff"
+	@echo "  typecheck    - Type-check with mypy"
 	@echo "  build        - Build distribution packages"
 	@echo "  clean        - Remove build artifacts"
 	@echo "  demo         - Run demo scripts"
@@ -106,4 +118,4 @@ help:
 	@echo "  pypitest     - Publish to TestPyPI"
 	@echo "  pypipublish  - Publish to PyPI"
 
-.PHONY: all init testgrammar pyparser test coverage build clean demo testpublish pypitest pypipublish help
+.PHONY: all init testgrammar pyparser test coverage lint typecheck build clean demo testpublish pypitest pypipublish help

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ registry.register('mine', MyPlanner)
 plan = registry.get('mine').solve(dp)
 ```
 
+### Documentation ###
+
+* [`docs/object-model.md`](docs/object-model.md) — full reference for the
+  parser object model and the planning layer.
+* [`skills/pddlpy/SKILL.md`](skills/pddlpy/SKILL.md) — an Agent Skill so coding
+  agents can drive the library (parse, ground, plan).
+
 ### Other Resources ###
 
 There are wonderful material at the the University of Edinburgh:

--- a/demo.py
+++ b/demo.py
@@ -16,9 +16,9 @@
 #
 #
 
-import sys
-import pddlpy
 import argparse
+
+import pddlpy
 
 parser = argparse.ArgumentParser(description='Demo PDDLPY.')
 parser.add_argument('demonumber', metavar='N', type=int, nargs='+',

--- a/docs/object-model.md
+++ b/docs/object-model.md
@@ -1,0 +1,101 @@
+# pddlpy object model
+
+This document describes the object model produced by parsing a PDDL
+domain/problem pair, and the planning layer built on top of it. For a quick
+start see the [README](../README.md); for agent-oriented usage see
+[`skills/pddlpy/SKILL.md`](../skills/pddlpy/SKILL.md).
+
+```
+ANTLR4 grammar -> parse tree -> listener -> object model -> planning layer
+   pddl.g4          (generated)  DomainListener/   DomainProblem    pddlpy.planning
+                                 ProblemListener   Operator/Atom/…
+```
+
+## Layers
+
+| Layer | Module | Depends on |
+|-------|--------|-----------|
+| Grammar / parser | `pddlLexer`, `pddlParser`, `pddlListener` (generated from `pddl.g4`) | — |
+| Object model | `pddlpy.pddl` | grammar |
+| Planning | `pddlpy.planning` | object model only (never the grammar) |
+
+The boundary is enforced by a test: no planning module imports the grammar,
+and the model imports nothing from the planning layer.
+
+## Object model (`pddlpy.pddl`)
+
+### `DomainProblem(domainfile, problemfile)`
+The entry point. Parses both files and exposes:
+
+| Method | Returns |
+|--------|---------|
+| `initialstate()` | set of `Atom` — the problem's initial facts |
+| `goals()` | set of `Atom` — the (positive) goal facts |
+| `operators()` | names of the instantaneous actions |
+| `ground_operator(name)` | iterator of grounded `Operator` instances |
+| `durative_operators()` | names of the durative actions (#23) |
+| `ground_durative_operator(name)` | iterator of grounded `DurativeAction` |
+| `worldobjects()` | `{object: type or None}` |
+| `requirements()` | declared `:requirements` (e.g. `{":strips", ":typing"}`) |
+| `functions()` | `:functions` → ordered `(param, type)` list |
+| `initial_numeric()` | `{ground function head: value}` |
+| `metric()` | `(optimization, expr_text)` or `None` |
+
+### `Atom`
+A predicate applied to terms, e.g. `(on ?x ?y)`. `predicate` is
+`[name, *terms]`; `ground(varvals)` substitutes variables and returns a plain
+tuple. **`Atom` has no value equality** — `initialstate()`/`goals()` hold
+`Atom` objects, while a *grounded* `Operator`'s precondition/effect sets hold
+tuples. Normalize with `pddlpy.planning.atom_tuple` (or compare `repr`s).
+
+### `Operator`
+An instantaneous action, grounded or not. Fields: `operator_name`,
+`variable_list`, `precondition_pos`/`precondition_neg`,
+`precondition_connective` (`'and'`/`'or'`, #13), `effect_pos`/`effect_neg`,
+and the numeric `precondition_num`/`effect_num` (#11).
+
+### Numeric fluents (#11)
+`Expr` tree — `Num`, `Fluent`, `BinOp`, `Neg` — each with
+`ground(varvals)` and `value(valuation)`. `NumericConstraint.holds(valuation)`
+evaluates a numeric precondition; `NumericEffect.apply(valuation)` returns the
+`(head, new_value)` an effect produces.
+
+### `DurativeAction` (#23)
+A durative action with time-tagged `condition_pos`/`condition_neg` keyed by
+`'start'`/`'over'`/`'end'`, `effect_pos`/`effect_neg` keyed by
+`'start'`/`'end'`, and a `duration`. Recovered into the model but **not**
+solved by the reference planners (they are non-temporal).
+
+## Planning layer (`pddlpy.planning`)
+
+- **`State`** — immutable, hashable set of ground atoms plus a numeric fluent
+  valuation. `State.from_problem(dp)`, `state.applicable(op)`,
+  `state.apply(op)`, `state.satisfies(goals)`.
+- **`Plan`** — ordered grounded actions with a `cost`.
+- **`GroundedTask`** — grounds every operator once; `successors(state)` and
+  `is_goal(state)`. Shared by all planners.
+- **`Planner`** ABC — `solve(domainproblem) -> Plan | None`, with a
+  `capabilities` set and fail-fast capability/`:requirements` checks (#9).
+- **`registry`** — register/get planners by name.
+- **Reference planners** — `bfs`, `astar` (goal-count heuristic), `gbfs`,
+  `ucs` (cost-optimal, #3).
+
+```python
+from pddlpy import DomainProblem
+from pddlpy.planning import get
+
+dp = DomainProblem("domain.pddl", "problem.pddl")
+plan = get("astar").solve(dp)
+print(plan.cost, plan.action_names())
+```
+
+## Known limitations
+
+- **Type hierarchies (#22):** grounding matches a parameter's declared type
+  exactly, so multi-level type hierarchies (e.g. logistics) do not fully
+  ground. Single-level typing (gripper) and untyped domains (blocksworld)
+  work.
+- **Disjunctive/ADL preconditions:** the `or` connective is preserved but not
+  evaluated; the reference planners reject such domains via capability checks.
+- **Durative actions:** recovered into the model but not solved (non-temporal
+  planners).

--- a/pddlpy/__init__.py
+++ b/pddlpy/__init__.py
@@ -20,3 +20,5 @@
 
 from .pddl import DomainProblem
 
+__all__ = ["DomainProblem"]
+

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -18,6 +18,14 @@
 #
 #
 
+"""Core pddlpy object model and PDDL parser glue.
+
+Parses PDDL domain/problem files via the generated ANTLR listeners into a
+``DomainProblem`` exposing the initial state, goals, operators (instantaneous
+and durative), numeric functions and the optimization metric. See
+``docs/object-model.md`` for an overview and ``pddlpy.planning`` for the
+solver layer built on top of this model.
+"""
 from __future__ import annotations
 
 import itertools
@@ -39,6 +47,13 @@ Valuation = Dict[GroundAtom, float]
 
 
 class Atom():
+    """A predicate applied to terms, e.g. ``(on ?x ?y)``.
+
+    ``predicate`` is a sequence ``[name, *terms]``; terms beginning with ``?``
+    are variables. ``ground(varvals)`` substitutes variables and returns a
+    plain tuple. Note: ``Atom`` has no value equality — compare grounded atoms
+    as tuples (see ``pddlpy.planning.atom_tuple``).
+    """
     def __init__(self, predicate: Sequence[str]) -> None:
         self.predicate = predicate
 
@@ -337,6 +352,9 @@ class DurativeAction():
 
 
 class DomainListener(pddlListener):
+    """ANTLR walk listener that builds the domain side of the model: types,
+    constants, predicates, :functions, :requirements, and the (instantaneous
+    and durative) action definitions."""
     def __init__(self):
         self.typesdef = False
         self.objects = {}
@@ -562,6 +580,9 @@ class DomainListener(pddlListener):
 
 
 class ProblemListener(pddlListener):
+    """ANTLR walk listener that builds the problem side of the model: objects,
+    the initial state (symbolic atoms and numeric assignments), the goal, and
+    the optimization metric."""
 
     def __init__(self):
         self.objects = {}

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -20,15 +20,15 @@
 
 from __future__ import annotations
 
-from typing import (Any, Dict, Iterator, List, Optional, Sequence, Tuple)
-
-from antlr4 import *
-from .pddlLexer import pddlLexer
-from .pddlParser import pddlParser
-from .pddlListener import pddlListener
-
 import itertools
 import operator as _operator
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+
+from antlr4 import CommonTokenStream, FileStream, ParseTreeWalker
+
+from .pddlLexer import pddlLexer
+from .pddlListener import pddlListener
+from .pddlParser import pddlParser
 
 #: A binding of variable names to values, e.g. {"?x": "a"}.
 VarVals = Dict[str, str]
@@ -377,7 +377,6 @@ class DomainListener(pddlListener):
 
     def enterActionDef(self, ctx):
         opname = ctx.actionSymbol().getText()
-        opvars = {}
         self.scopes.append(Operator(opname))
 
     def exitActionDef(self, ctx):
@@ -432,7 +431,7 @@ class DomainListener(pddlListener):
         self.scopes.append(Operator(None))
 
     def exitPredicatesDef(self, ctx):
-        dummyop = self.scopes.pop()
+        self.scopes.pop()
 
     def enterTypesDef(self, ctx):
         self.scopes.append(Obj())

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -18,6 +18,10 @@
 #
 #
 
+from __future__ import annotations
+
+from typing import (Any, Dict, Iterator, List, Optional, Sequence, Tuple)
+
 from antlr4 import *
 from .pddlLexer import pddlLexer
 from .pddlParser import pddlParser
@@ -26,15 +30,22 @@ from .pddlListener import pddlListener
 import itertools
 import operator as _operator
 
+#: A binding of variable names to values, e.g. {"?x": "a"}.
+VarVals = Dict[str, str]
+#: A ground atom as a tuple of strings, e.g. ("on", "a", "b").
+GroundAtom = Tuple[str, ...]
+#: A numeric fluent valuation: ground function head -> value.
+Valuation = Dict[GroundAtom, float]
+
 
 class Atom():
-    def __init__(self, predicate):
+    def __init__(self, predicate: Sequence[str]) -> None:
         self.predicate = predicate
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(tuple(self.predicate))
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> GroundAtom:
         g = [ varvals[v] if v in varvals else v for v in self.predicate ]
         return tuple(g)
 
@@ -47,37 +58,37 @@ class Atom():
 
 class Expr():
     """Base class for numeric expression nodes."""
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "Expr":
         return self
 
-    def value(self, valuation):
+    def value(self, valuation: Valuation) -> float:
         raise NotImplementedError  # pragma: no cover - abstract
 
 
 class Num(Expr):
     """A numeric literal."""
-    def __init__(self, value):
+    def __init__(self, value: Any) -> None:
         self.num = float(value)
 
-    def value(self, valuation):
+    def value(self, valuation: Valuation) -> float:
         return self.num
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.num)
 
 
 class Fluent(Expr):
     """A (possibly ungrounded) function head, e.g. ('fuel', '?v')."""
-    def __init__(self, head):
-        self.head = tuple(head)
+    def __init__(self, head: Sequence[str]) -> None:
+        self.head: GroundAtom = tuple(head)
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "Fluent":
         return Fluent(tuple(varvals[s] if s in varvals else s for s in self.head))
 
-    def value(self, valuation):
+    def value(self, valuation: Valuation) -> float:
         return valuation.get(self.head, 0.0)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self.head)
 
 
@@ -86,33 +97,33 @@ class BinOp(Expr):
     _ops = {'+': _operator.add, '-': _operator.sub,
             '*': _operator.mul, '/': _operator.truediv}
 
-    def __init__(self, op, left, right):
+    def __init__(self, op: str, left: Expr, right: Expr) -> None:
         self.op = op
         self.left = left
         self.right = right
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "BinOp":
         return BinOp(self.op, self.left.ground(varvals), self.right.ground(varvals))
 
-    def value(self, valuation):
+    def value(self, valuation: Valuation) -> float:
         return self._ops[self.op](self.left.value(valuation), self.right.value(valuation))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "(%s %r %r)" % (self.op, self.left, self.right)
 
 
 class Neg(Expr):
     """Unary minus."""
-    def __init__(self, operand):
+    def __init__(self, operand: Expr) -> None:
         self.operand = operand
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "Neg":
         return Neg(self.operand.ground(varvals))
 
-    def value(self, valuation):
+    def value(self, valuation: Valuation) -> float:
         return -self.operand.value(valuation)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "(- %r)" % (self.operand,)
 
 
@@ -121,32 +132,32 @@ class NumericConstraint():
     _cmp = {'>': _operator.gt, '<': _operator.lt, '=': _operator.eq,
             '>=': _operator.ge, '<=': _operator.le}
 
-    def __init__(self, comp, lhs, rhs):
+    def __init__(self, comp: str, lhs: Expr, rhs: Expr) -> None:
         self.comp = comp
         self.lhs = lhs
         self.rhs = rhs
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "NumericConstraint":
         return NumericConstraint(self.comp, self.lhs.ground(varvals), self.rhs.ground(varvals))
 
-    def holds(self, valuation):
+    def holds(self, valuation: Valuation) -> bool:
         return self._cmp[self.comp](self.lhs.value(valuation), self.rhs.value(valuation))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "(%s %r %r)" % (self.comp, self.lhs, self.rhs)
 
 
 class NumericEffect():
     """A numeric effect, e.g. (decrease (fuel ?v) (fuel-cost ?from ?to))."""
-    def __init__(self, op, head, expr):
+    def __init__(self, op: str, head: Fluent, expr: Expr) -> None:
         self.op = op
         self.head = head   # a Fluent
         self.expr = expr
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "NumericEffect":
         return NumericEffect(self.op, self.head.ground(varvals), self.expr.ground(varvals))
 
-    def apply(self, valuation):
+    def apply(self, valuation: Valuation) -> Tuple[GroundAtom, float]:
         """Return (ground_head_tuple, new_value) given the current valuation."""
         key = self.head.head
         rhs = self.expr.value(valuation)
@@ -168,13 +179,13 @@ class NumericEffect():
         return "(%s %r %r)" % (self.op, self.head, self.expr)
 
 
-def _parse_fhead(ctx):
+def _parse_fhead(ctx: Any) -> GroundAtom:
     """Build a function-head tuple from an FHeadContext."""
     name = ctx.functionSymbol().getText()
     return tuple([name] + [t.getText() for t in ctx.term()])
 
 
-def _nth_fexp(ctx, i):
+def _nth_fexp(ctx: Any, i: int) -> Any:
     """Return the i-th fExp child of ctx. ANTLR generates a single-value
     accessor when fExp occurs once in a rule and a list accessor when it
     occurs more than once; this smooths over both."""
@@ -182,7 +193,7 @@ def _nth_fexp(ctx, i):
     return fe[i] if isinstance(fe, list) else fe
 
 
-def _parse_fexp(ctx):
+def _parse_fexp(ctx: Any) -> Expr:
     """Build an Expr from an FExpContext."""
     if ctx.NUMBER() is not None:
         return Num(ctx.NUMBER().getText())
@@ -196,7 +207,7 @@ def _parse_fexp(ctx):
     return Neg(_parse_fexp(_nth_fexp(ctx, 0)))
 
 
-def _parse_fcomp(ctx):
+def _parse_fcomp(ctx: Any) -> NumericConstraint:
     """Build a NumericConstraint from an FCompContext."""
     return NumericConstraint(ctx.binaryComp().getText(),
                              _parse_fexp(_nth_fexp(ctx, 0)),
@@ -250,18 +261,18 @@ class Operator():
         effect_num -- a list of NumericEffect numeric effects (#11),
                             e.g. (decrease (fuel ?v) 5).
     """
-    def __init__(self, name):
+    def __init__(self, name: Optional[str]) -> None:
         self.operator_name = name
-        self.variable_list = {}
-        self.precondition_pos = set()
-        self.precondition_neg = set()
+        self.variable_list: Dict[str, Optional[str]] = {}
+        self.precondition_pos: set = set()
+        self.precondition_neg: set = set()
         self.precondition_connective = 'and'
-        self.effect_pos = set()
-        self.effect_neg = set()
-        self.precondition_num = []
-        self.effect_num = []
+        self.effect_pos: set = set()
+        self.effect_neg: set = set()
+        self.precondition_num: List[NumericConstraint] = []
+        self.effect_num: List[NumericEffect] = []
 
-    def __str__(self):
+    def __str__(self) -> str:
         templ = "Operator Name: %s\n\tVariables: %s\n\t" + \
                 "Precondition Connective: %s\n\t" + \
                 "Positive Preconditions: %s\n\t" + \
@@ -293,16 +304,16 @@ class DurativeAction():
     CONDITION_TIMES = ('start', 'over', 'end')
     EFFECT_TIMES = ('start', 'end')
 
-    def __init__(self, name):
+    def __init__(self, name: Optional[str]) -> None:
         self.operator_name = name
-        self.variable_list = {}
-        self.duration = None
-        self.condition_pos = {t: set() for t in self.CONDITION_TIMES}
-        self.condition_neg = {t: set() for t in self.CONDITION_TIMES}
-        self.effect_pos = {t: set() for t in self.EFFECT_TIMES}
-        self.effect_neg = {t: set() for t in self.EFFECT_TIMES}
+        self.variable_list: Dict[str, Optional[str]] = {}
+        self.duration: Optional[float] = None
+        self.condition_pos: Dict[str, set] = {t: set() for t in self.CONDITION_TIMES}
+        self.condition_neg: Dict[str, set] = {t: set() for t in self.CONDITION_TIMES}
+        self.effect_pos: Dict[str, set] = {t: set() for t in self.EFFECT_TIMES}
+        self.effect_neg: Dict[str, set] = {t: set() for t in self.EFFECT_TIMES}
 
-    def ground(self, varvals):
+    def ground(self, varvals: VarVals) -> "DurativeAction":
         """Return a grounded copy with variables substituted and atoms turned
         into tuples."""
         g = DurativeAction(self.operator_name)
@@ -316,7 +327,7 @@ class DurativeAction():
             g.effect_neg[t] = set(a.ground(varvals) for a in self.effect_neg[t])
         return g
 
-    def __str__(self):
+    def __str__(self) -> str:
         return ("Durative Action: %s\n\tVariables: %s\n\tDuration: %s\n\t"
                 "Conditions (+): %s\n\tConditions (-): %s\n\t"
                 "Effects (+): %s\n\tEffects (-): %s\n") % (
@@ -636,7 +647,7 @@ class ProblemListener(pddlListener):
 
 class DomainProblem():
 
-    def __init__(self, domainfile, problemfile):
+    def __init__(self, domainfile: str, problemfile: str) -> None:
         """Parses a PDDL domain and problem files and
         returns an object representing them.
 
@@ -665,48 +676,48 @@ class DomainProblem():
         # a dict where keys are op names and values
         # a dict where keys are var names and values
         # a list of possible symbols.
-        self.vargroundspace = {}
+        self.vargroundspace: Dict[str, Dict[str, List[str]]] = {}
 
-    def operators(self):
+    def operators(self) -> Any:
         """Returns an iterator of the names of the (instantaneous) actions
         defined in the domain file. Durative actions are listed separately by
         durative_operators().
         """
         return self.domain.operators.keys()
 
-    def durative_operators(self):
+    def durative_operators(self) -> Any:
         """Returns an iterator of the names of the durative actions (#23)
         defined in the domain file.
         """
         return self.domain.durative_operators.keys()
 
-    def requirements(self):
+    def requirements(self) -> set:
         """Returns the set of :requirements keywords declared in the domain
         (e.g. {':strips', ':typing'}), normalized to lowercase. Empty if the
         domain declares none.
         """
         return set(self.domain.requirements)
 
-    def functions(self):
+    def functions(self) -> Dict[str, List[Tuple[str, Optional[str]]]]:
         """Returns a dict mapping each declared :functions name to its ordered
         list of (param_name, type) pairs. Empty if the domain declares none.
         """
         return dict(self.domain.functions)
 
-    def initial_numeric(self):
+    def initial_numeric(self) -> Valuation:
         """Returns a dict mapping each ground function head tuple to its
         initial numeric value, e.g. {('fuel', 'truck'): 100.0}.
         """
         return dict(self.problem.init_numeric)
 
-    def metric(self):
+    def metric(self) -> Optional[Tuple[str, str]]:
         """Returns the optimization metric as ``(optimization, expr_text)``,
         e.g. ``('minimize', '(total-cost)')``, or ``None`` if the problem
         declares no metric.
         """
         return self.problem.metric
 
-    def ground_operator(self, op_name):
+    def ground_operator(self, op_name: str) -> Iterator[Operator]:
         """Returns an interator of Operator instances. Each item of the iterator
         is a grounded instance.
 
@@ -728,7 +739,7 @@ class DomainProblem():
             gop.effect_num = [ e.ground( st ) for e in op.effect_num ]
             yield gop
 
-    def ground_durative_operator(self, op_name):
+    def ground_durative_operator(self, op_name: str) -> Iterator[DurativeAction]:
         """Returns an iterator of grounded DurativeAction instances (#23)."""
         op = self.domain.durative_operators[op_name]
         self._set_operator_groundspace( op_name, op.variable_list.items() )
@@ -754,19 +765,19 @@ class DomainProblem():
         # cartesian product.
         return itertools.product(*expanded)
 
-    def initialstate(self):
-        """Returns a set of atoms (tuples of strings) corresponding to the intial
+    def initialstate(self) -> set:
+        """Returns a set of atoms (Atom objects) corresponding to the initial
         state defined in the problem file.
         """
         return self.problem.initialstate
 
-    def goals(self):
-        """Returns a set of atoms (tuples of strings) corresponding to the goals
+    def goals(self) -> set:
+        """Returns a set of atoms (Atom objects) corresponding to the goals
         defined in the problem file.
         """
         return self.problem.goals
 
-    def worldobjects(self):
+    def worldobjects(self) -> Dict[str, Optional[str]]:
         """Returns a dictionary of key value pairs where the key is the name of
         an object and the value is it's type (None in case is untyped.)
         """

--- a/pddlpy/planning/__init__.py
+++ b/pddlpy/planning/__init__.py
@@ -5,23 +5,23 @@ Sits strictly above the domain/problem object model: it imports from
 (``pddlLexer`` / ``pddlParser`` / ``pddlListener``). The model, in turn,
 imports nothing from this package.
 """
-from .state import State, Plan, atom_tuple
-from .grounding import GroundedTask
 from .base import (
     Planner,
     PlannerError,
     UnsupportedRequirementsError,
     validate_requirements,
 )
-from .registry import registry, register, get
+from .costs import TOTAL_COST, action_cost, plan_cost
+from .grounding import GroundedTask
+from .registry import get, register, registry
 from .search import (
-    BFSPlanner,
+    STRIPS_CAPABILITIES,
     AStarPlanner,
+    BFSPlanner,
     GBFSPlanner,
     UniformCostPlanner,
-    STRIPS_CAPABILITIES,
 )
-from .costs import action_cost, plan_cost, TOTAL_COST
+from .state import Plan, State, atom_tuple
 
 __all__ = [
     "State",

--- a/pddlpy/planning/base.py
+++ b/pddlpy/planning/base.py
@@ -12,9 +12,16 @@ Two guards run before search (fail fast, PRD §7):
 * **Capability negotiation**: every declared requirement must be in the
   planner's ``capabilities``; otherwise the planner refuses the task.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Dict, FrozenSet, Optional, Set
 
 from .grounding import GroundedTask
+
+if TYPE_CHECKING:
+    from pddlpy.pddl import DomainProblem
+    from .state import Plan
 
 
 class PlannerError(Exception):
@@ -27,16 +34,16 @@ class UnsupportedRequirementsError(PlannerError):
 
 # Map a detectable feature to the requirement keywords that permit it.
 # ':adl' is the umbrella requirement implying typing + negative + disjunctive.
-_FEATURE_REQUIREMENTS = {
+_FEATURE_REQUIREMENTS: Dict[str, Set[str]] = {
     "typing": {":typing", ":adl"},
     "negative-preconditions": {":negative-preconditions", ":adl"},
     "disjunctive-preconditions": {":disjunctive-preconditions", ":adl"},
 }
 
 
-def _used_features(domainproblem):
+def _used_features(domainproblem: "DomainProblem") -> Set[str]:
     """Detect which (enforceable) PDDL features a domain actually uses."""
-    features = set()
+    features: Set[str] = set()
     if domainproblem.domain.typesdef or any(
         t is not None for t in domainproblem.worldobjects().values()
     ):
@@ -49,7 +56,7 @@ def _used_features(domainproblem):
     return features
 
 
-def validate_requirements(domainproblem):
+def validate_requirements(domainproblem: "DomainProblem") -> None:
     """#9: ensure used features are declared in ``:requirements``.
 
     Only enforced when the domain declares at least one requirement (i.e. it
@@ -78,9 +85,9 @@ class Planner(ABC):
     """
 
     #: requirement keywords this planner supports
-    capabilities = frozenset()
+    capabilities: FrozenSet[str] = frozenset()
 
-    def check_capabilities(self, domainproblem):
+    def check_capabilities(self, domainproblem: "DomainProblem") -> None:
         """Raise if the domain declares a requirement beyond this planner's
         capabilities."""
         unsupported = domainproblem.requirements() - set(self.capabilities)
@@ -90,13 +97,13 @@ class Planner(ABC):
                 % (type(self).__name__, sorted(unsupported))
             )
 
-    def prepare(self, domainproblem):
+    def prepare(self, domainproblem: "DomainProblem") -> GroundedTask:
         """Run #9 + capability checks, then build the GroundedTask."""
         validate_requirements(domainproblem)
         self.check_capabilities(domainproblem)
         return GroundedTask(domainproblem)
 
     @abstractmethod
-    def solve(self, domainproblem):
+    def solve(self, domainproblem: "DomainProblem") -> "Optional[Plan]":
         """Return a ``Plan`` reaching the goal, or ``None`` if none exists."""
         raise NotImplementedError  # pragma: no cover - abstract

--- a/pddlpy/planning/base.py
+++ b/pddlpy/planning/base.py
@@ -21,6 +21,7 @@ from .grounding import GroundedTask
 
 if TYPE_CHECKING:
     from pddlpy.pddl import DomainProblem
+
     from .state import Plan
 
 

--- a/pddlpy/planning/costs.py
+++ b/pddlpy/planning/costs.py
@@ -7,11 +7,19 @@ just a numeric fluent (Phase 2), so the cost machinery is thin: read the
 ``total-cost`` fluent for the final plan cost.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:
+    from pddlpy.pddl import Operator
+    from .state import GroundAtom, State
+
 #: The reserved cost fluent head.
 TOTAL_COST = ("total-cost",)
 
 
-def action_cost(operator, state):
+def action_cost(operator: "Operator", state: "State") -> float:
     """The cost of applying ``operator`` in ``state``.
 
     Sums the ``(increase (total-cost) expr)`` effects (each ``expr`` evaluated
@@ -27,7 +35,7 @@ def action_cost(operator, state):
     return total if found else 1.0
 
 
-def plan_cost(goal_state, actions):
+def plan_cost(goal_state: "State", actions: Sequence["Operator"]) -> float:
     """The cost of a found plan: the accumulated ``total-cost`` if the domain
     tracks it, otherwise the number of actions."""
     if TOTAL_COST in goal_state.fluents:

--- a/pddlpy/planning/costs.py
+++ b/pddlpy/planning/costs.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from pddlpy.pddl import Operator
-    from .state import GroundAtom, State
+
+    from .state import State
 
 #: The reserved cost fluent head.
 TOTAL_COST = ("total-cost",)

--- a/pddlpy/planning/grounding.py
+++ b/pddlpy/planning/grounding.py
@@ -7,7 +7,7 @@ without re-deriving it (PRD §5.2).
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterator, List, Tuple
+from typing import TYPE_CHECKING, Iterator, List, Tuple
 
 from .state import State
 

--- a/pddlpy/planning/grounding.py
+++ b/pddlpy/planning/grounding.py
@@ -5,7 +5,14 @@ function over ``State``. Blind-search planners use only ``successors`` and
 ``is_goal``; a future heuristic planner reuses the same grounded action set
 without re-deriving it (PRD §5.2).
 """
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterator, List, Tuple
+
 from .state import State
+
+if TYPE_CHECKING:
+    from pddlpy.pddl import DomainProblem, Operator
 
 
 class GroundedTask:
@@ -17,22 +24,22 @@ class GroundedTask:
         actions -- the list of all grounded ``Operator`` instances.
     """
 
-    def __init__(self, domainproblem):
+    def __init__(self, domainproblem: "DomainProblem") -> None:
         self.domainproblem = domainproblem
-        self.initial = State.from_problem(domainproblem)
+        self.initial: State = State.from_problem(domainproblem)
         self.goals = domainproblem.goals()
-        self.actions = [
+        self.actions: List["Operator"] = [
             gop
             for name in domainproblem.operators()
             for gop in domainproblem.ground_operator(name)
         ]
 
-    def successors(self, state):
+    def successors(self, state: State) -> Iterator[Tuple["Operator", State]]:
         """Yield ``(action, successor_state)`` for every applicable action."""
         for action in self.actions:
             if state.applicable(action):
                 yield action, state.apply(action)
 
-    def is_goal(self, state):
+    def is_goal(self, state: State) -> bool:
         """True if ``state`` satisfies the goal."""
         return state.satisfies(self.goals)

--- a/pddlpy/planning/registry.py
+++ b/pddlpy/planning/registry.py
@@ -5,18 +5,24 @@
     planner = registry.get("astar")     # -> an AStarPlanner instance
     plan = planner.solve(domainproblem)
 """
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Type
+
+if TYPE_CHECKING:
+    from .base import Planner
 
 
 class PlannerRegistry:
     """Maps short names to ``Planner`` subclasses."""
 
-    def __init__(self):
-        self._planners = {}
+    def __init__(self) -> None:
+        self._planners: Dict[str, Type["Planner"]] = {}
 
-    def register(self, name, planner_cls):
+    def register(self, name: str, planner_cls: Type["Planner"]) -> None:
         self._planners[name] = planner_cls
 
-    def get(self, name, *args, **kwargs):
+    def get(self, name: str, *args: Any, **kwargs: Any) -> "Planner":
         """Return a new planner instance registered under ``name``."""
         if name not in self._planners:
             raise KeyError(
@@ -25,18 +31,18 @@ class PlannerRegistry:
             )
         return self._planners[name](*args, **kwargs)
 
-    def names(self):
+    def names(self) -> List[str]:
         return sorted(self._planners)
 
 
 registry = PlannerRegistry()
 
 
-def register(name, planner_cls):
+def register(name: str, planner_cls: Type["Planner"]) -> None:
     """Register ``planner_cls`` under ``name`` in the default registry."""
     registry.register(name, planner_cls)
 
 
-def get(name, *args, **kwargs):
+def get(name: str, *args: Any, **kwargs: Any) -> "Planner":
     """Get a planner instance from the default registry."""
     return registry.get(name, *args, **kwargs)

--- a/pddlpy/planning/search.py
+++ b/pddlpy/planning/search.py
@@ -10,28 +10,38 @@ These prove the ``Planner`` contract; they are not performance entrants
 * ``UniformCostPlanner`` — Dijkstra over action costs; cost-optimal for
   action-cost domains (#3).
 """
+from __future__ import annotations
+
 import heapq
 import itertools
 from collections import deque
+from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional, Tuple
 
 from .base import Planner
-from .state import Plan, atom_tuple
+from .state import Plan, State, atom_tuple
 from .registry import register
 from .costs import action_cost, plan_cost
+
+if TYPE_CHECKING:
+    from pddlpy.pddl import DomainProblem, Operator
+    from .state import GroundAtom
+
+#: Parent-pointer map used to reconstruct a plan.
+_CameFrom = Dict[State, Tuple[State, "Operator"]]
 
 #: Requirements the reference planners can handle. Numeric fluents (#11) and
 #: action costs (#3) are supported because State evaluates numeric
 #: preconditions/effects during successor generation; the goal-count heuristic
 #: ignores them (still admissible for the symbolic goal).
-STRIPS_CAPABILITIES = frozenset(
+STRIPS_CAPABILITIES: FrozenSet[str] = frozenset(
     {":strips", ":typing", ":negative-preconditions", ":equality",
      ":fluents", ":numeric-fluents", ":action-costs"}
 )
 
 
-def _reconstruct(came_from, state):
+def _reconstruct(came_from: _CameFrom, state: State) -> List["Operator"]:
     """Walk parent pointers back to the start, returning the action list."""
-    actions = []
+    actions: List["Operator"] = []
     while state in came_from:
         prev, action = came_from[state]
         actions.append(action)
@@ -40,7 +50,7 @@ def _reconstruct(came_from, state):
     return actions
 
 
-def goal_count(goal_atoms, state):
+def goal_count(goal_atoms: "FrozenSet[GroundAtom]", state: State) -> int:
     """Heuristic: number of goal atoms not yet satisfied (admissible for
     unit costs)."""
     return len(goal_atoms - state.atoms)
@@ -51,14 +61,14 @@ class BFSPlanner(Planner):
 
     capabilities = STRIPS_CAPABILITIES
 
-    def solve(self, domainproblem):
+    def solve(self, domainproblem: "DomainProblem") -> Optional[Plan]:
         task = self.prepare(domainproblem)
         start = task.initial
         if task.is_goal(start):
             return Plan([])
-        frontier = deque([start])
+        frontier: "deque[State]" = deque([start])
         visited = {start}
-        came_from = {}
+        came_from: _CameFrom = {}
         while frontier:
             state = frontier.popleft()
             for action, succ in task.successors(state):
@@ -79,23 +89,25 @@ class _BestFirstPlanner(Planner):
 
     capabilities = STRIPS_CAPABILITIES
 
-    def _priority(self, g, h):
+    def _priority(self, g: float, h: float) -> float:
         raise NotImplementedError  # pragma: no cover - abstract
 
-    def _step_cost(self, action, state):
+    def _step_cost(self, action: "Operator", state: State) -> float:
         """Cost of one transition. Unit by default; cost-aware planners
         override."""
         return 1
 
-    def solve(self, domainproblem):
+    def solve(self, domainproblem: "DomainProblem") -> Optional[Plan]:
         task = self.prepare(domainproblem)
         goal_atoms = frozenset(atom_tuple(a) for a in task.goals)
         start = task.initial
         counter = itertools.count()  # tie-breaker; keeps States out of compares
         h0 = goal_count(goal_atoms, start)
-        frontier = [(self._priority(0, h0), 0, next(counter), start)]
-        best_g = {start: 0}
-        came_from = {}
+        frontier: List[Tuple[float, float, int, State]] = [
+            (self._priority(0, h0), 0, next(counter), start)
+        ]
+        best_g: Dict[State, float] = {start: 0}
+        came_from: _CameFrom = {}
         while frontier:
             _, g, _, state = heapq.heappop(frontier)
             if task.is_goal(state):
@@ -118,14 +130,14 @@ class _BestFirstPlanner(Planner):
 class AStarPlanner(_BestFirstPlanner):
     """A* with the goal-count heuristic (f = g + h), unit step cost."""
 
-    def _priority(self, g, h):
+    def _priority(self, g: float, h: float) -> float:
         return g + h
 
 
 class GBFSPlanner(_BestFirstPlanner):
     """Greedy best-first search (f = h)."""
 
-    def _priority(self, g, h):
+    def _priority(self, g: float, h: float) -> float:
         return h
 
 
@@ -134,10 +146,10 @@ class UniformCostPlanner(_BestFirstPlanner):
     action-cost domains (#3); falls back to unit cost when a domain declares
     none."""
 
-    def _priority(self, g, h):
+    def _priority(self, g: float, h: float) -> float:
         return g
 
-    def _step_cost(self, action, state):
+    def _step_cost(self, action: "Operator", state: State) -> float:
         return action_cost(action, state)
 
 

--- a/pddlpy/planning/search.py
+++ b/pddlpy/planning/search.py
@@ -18,12 +18,13 @@ from collections import deque
 from typing import TYPE_CHECKING, Dict, FrozenSet, List, Optional, Tuple
 
 from .base import Planner
-from .state import Plan, State, atom_tuple
-from .registry import register
 from .costs import action_cost, plan_cost
+from .registry import register
+from .state import Plan, State, atom_tuple
 
 if TYPE_CHECKING:
     from pddlpy.pddl import DomainProblem, Operator
+
     from .state import GroundAtom
 
 #: Parent-pointer map used to reconstruct a plan.

--- a/pddlpy/planning/state.py
+++ b/pddlpy/planning/state.py
@@ -5,9 +5,20 @@ This is the clean resolution to #21: the parser exposes ground atoms as
 (grounded ``Operator`` precondition/effect sets). ``State`` normalizes both
 to tuples so that applicability and goal checks work without manual casting.
 """
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
+
+if TYPE_CHECKING:
+    from pddlpy.pddl import Atom, DomainProblem, Operator
+
+#: A ground atom, e.g. ``("on", "a", "b")``.
+GroundAtom = Tuple[str, ...]
+#: A numeric fluent valuation: ground function head -> value.
+Valuation = Dict[GroundAtom, float]
 
 
-def atom_tuple(atom):
+def atom_tuple(atom: "Atom | GroundAtom | Iterable[str]") -> GroundAtom:
     """Normalize a ground atom to a plain tuple of strings.
 
     Accepts either a tuple (already normalized, e.g. from a grounded
@@ -33,28 +44,35 @@ class State:
 
     __slots__ = ("_atoms", "_fluents", "_key")
 
-    def __init__(self, atoms=(), fluents=None):
-        self._atoms = frozenset(atom_tuple(a) for a in atoms)
-        self._fluents = dict(fluents or {})
-        self._key = (self._atoms, frozenset(self._fluents.items()))
+    def __init__(
+        self,
+        atoms: Iterable[Any] = (),
+        fluents: Optional[Mapping[GroundAtom, float]] = None,
+    ) -> None:
+        self._atoms: frozenset[GroundAtom] = frozenset(atom_tuple(a) for a in atoms)
+        self._fluents: Valuation = dict(fluents or {})
+        self._key: Tuple[frozenset[GroundAtom], frozenset] = (
+            self._atoms,
+            frozenset(self._fluents.items()),
+        )
 
     @property
-    def atoms(self):
+    def atoms(self) -> frozenset[GroundAtom]:
         return self._atoms
 
     @property
-    def fluents(self):
+    def fluents(self) -> Valuation:
         return self._fluents
 
     # -- constructors -----------------------------------------------------
     @classmethod
-    def from_problem(cls, domainproblem):
+    def from_problem(cls, domainproblem: "DomainProblem") -> "State":
         """Build the initial state (atoms + numeric fluents) from a parsed
         ``DomainProblem``."""
         return cls(domainproblem.initialstate(), domainproblem.initial_numeric())
 
     # -- planning operations (resolve #21) -------------------------------
-    def applicable(self, operator):
+    def applicable(self, operator: "Operator") -> bool:
         """True if a grounded ``operator`` is applicable in this state.
 
         Conjunctive semantics: all positive preconditions hold, no negative
@@ -69,7 +87,7 @@ class State:
             return False
         return all(c.holds(self._fluents) for c in operator.precondition_num)
 
-    def apply(self, operator):
+    def apply(self, operator: "Operator") -> "State":
         """Return the successor ``State`` after applying a grounded operator.
 
         Delete effects are removed first, then add effects are added
@@ -78,7 +96,7 @@ class State:
         """
         add = {atom_tuple(a) for a in operator.effect_pos}
         delete = {atom_tuple(a) for a in operator.effect_neg}
-        fluents = self._fluents
+        fluents: Valuation = self._fluents
         if operator.effect_num:
             updates = [eff.apply(self._fluents) for eff in operator.effect_num]
             fluents = dict(self._fluents)
@@ -86,27 +104,27 @@ class State:
                 fluents[key] = value
         return State((self._atoms - delete) | add, fluents)
 
-    def satisfies(self, goals):
+    def satisfies(self, goals: Iterable[Any]) -> bool:
         """True if every (positive) goal atom holds in this state."""
         return {atom_tuple(a) for a in goals} <= self._atoms
 
     # -- container protocol ----------------------------------------------
-    def __contains__(self, atom):
+    def __contains__(self, atom: Any) -> bool:
         return atom_tuple(atom) in self._atoms
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[GroundAtom]:
         return iter(self._atoms)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._atoms)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, State) and self._key == other._key
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._key)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._fluents:
             return "State(%s, %s)" % (sorted(self._atoms), dict(sorted(self._fluents.items())))
         return "State(%s)" % sorted(self._atoms)
@@ -122,21 +140,25 @@ class Plan:
 
     __slots__ = ("actions", "cost")
 
-    def __init__(self, actions=(), cost=None):
-        self.actions = tuple(actions)
-        self.cost = len(self.actions) if cost is None else cost
+    def __init__(
+        self,
+        actions: Iterable["Operator"] = (),
+        cost: Optional[float] = None,
+    ) -> None:
+        self.actions: Tuple["Operator", ...] = tuple(actions)
+        self.cost: float = len(self.actions) if cost is None else cost
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator["Operator"]:
         return iter(self.actions)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.actions)
 
-    def action_names(self):
+    def action_names(self) -> List[Tuple[str, Dict[str, Any]]]:
         """List of ``(operator_name, variable_bindings)`` for each action."""
         return [(a.operator_name, a.variable_list) for a in self.actions]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         steps = ", ".join(
             "%s(%s)" % (a.operator_name, ", ".join(str(v) for v in a.variable_list.values()))
             for a in self.actions

--- a/pddlpy/planning/state.py
+++ b/pddlpy/planning/state.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
 
 if TYPE_CHECKING:
-    from pddlpy.pddl import Atom, DomainProblem, Operator
+    from pddlpy.pddl import DomainProblem, Operator
 
 #: A ground atom, e.g. ``("on", "a", "b")``.
 GroundAtom = Tuple[str, ...]
@@ -18,7 +18,7 @@ GroundAtom = Tuple[str, ...]
 Valuation = Dict[GroundAtom, float]
 
 
-def atom_tuple(atom: "Atom | GroundAtom | Iterable[str]") -> GroundAtom:
+def atom_tuple(atom: Any) -> GroundAtom:
     """Normalize a ground atom to a plain tuple of strings.
 
     Accepts either a tuple (already normalized, e.g. from a grounded
@@ -154,7 +154,7 @@ class Plan:
     def __len__(self) -> int:
         return len(self.actions)
 
-    def action_names(self) -> List[Tuple[str, Dict[str, Any]]]:
+    def action_names(self) -> List[Tuple[Optional[str], Dict[str, Optional[str]]]]:
         """List of ``(operator_name, variable_bindings)`` for each action."""
         return [(a.operator_name, a.variable_list) for a in self.actions]
 

--- a/pddlpy/test.py
+++ b/pddlpy/test.py
@@ -1,5 +1,7 @@
 import unittest
+
 from pddlpy import DomainProblem
+
 
 class TestStringMethods(unittest.TestCase):
     domainfile = "examples-pddl/domain-0%d.pddl" % 1
@@ -7,7 +9,6 @@ class TestStringMethods(unittest.TestCase):
 
     def test_ground(self):
         domprob = DomainProblem(self.domainfile, self.problemfile)
-        freeop = domprob.domain.operators["op2"]
         all_grounded_opers = domprob.ground_operator("op2")
         for gop in all_grounded_opers:
             if gop.precondition_pos == set( [('S','R','C'),('S','R','S')] ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ dev = [
     "build>=1.0.0",
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
+    "ruff>=0.6.0",
+    "mypy>=1.11.0",
 ]
 
 [tool.pytest.ini_options]
@@ -83,3 +85,33 @@ omit = [
     "pddlpy/pddlListener.py",
     "pddlpy/test.py",
 ]
+
+# Generated ANTLR parser files are machine output, not ours — exclude them
+# from linting and type checking everywhere.
+[tool.ruff]
+line-length = 100
+extend-exclude = [
+    "pddlpy/pddlLexer.py",
+    "pddlpy/pddlParser.py",
+    "pddlpy/pddlListener.py",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+# E501 (line length) is noisy on the existing model code; the formatter
+# handles wrapping when desired.
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["pddlpy"]
+# antlr4 runtime ships no type stubs.
+ignore_missing_imports = true
+# Generated parser files are excluded from type checking.
+exclude = '(pddlLexer|pddlParser|pddlListener)\.py$'
+
+# The planning layer is fully typed; hold it to a higher standard.
+[[tool.mypy.overrides]]
+module = "pddlpy.planning.*"
+disallow_untyped_defs = true
+warn_return_any = true

--- a/skills/pddlpy/SKILL.md
+++ b/skills/pddlpy/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: pddlpy
+description: Parse PDDL domain/problem files and solve them with pddlpy. Use when working with PDDL planning files — parsing a domain/problem, inspecting the initial state/goals/operators, grounding actions, evaluating numeric fluents or action costs, or running a reference planner (BFS/A*/GBFS/UCS) to produce a plan.
+---
+
+# pddlpy
+
+`pddlpy` parses PDDL into an object model and solves STRIPS-family problems
+with built-in reference planners. It supports STRIPS, typing, numeric fluents,
+and action costs; durative actions are parsed but not solved.
+
+## Setup
+
+```bash
+uv sync          # install (project uses uv)
+```
+
+Import: `from pddlpy import DomainProblem` and `from pddlpy.planning import get`.
+
+## Parse a domain + problem
+
+```python
+from pddlpy import DomainProblem
+
+dp = DomainProblem("domain.pddl", "problem.pddl")
+dp.initialstate()      # set of Atom (initial facts)
+dp.goals()             # set of Atom (goal facts)
+list(dp.operators())   # action names
+dp.requirements()      # e.g. {":strips", ":typing"}
+dp.functions()         # numeric :functions, if any
+dp.metric()            # ("minimize", "(total-cost)") or None
+```
+
+## Ground an operator
+
+```python
+for op in dp.ground_operator("move"):
+    op.variable_list        # {"?from": "a", "?to": "b"}
+    op.precondition_pos     # set of ground atom tuples
+    op.effect_pos / op.effect_neg
+    op.precondition_num / op.effect_num   # numeric (NumericConstraint / NumericEffect)
+```
+
+## Solve
+
+```python
+from pddlpy.planning import get
+
+plan = get("astar").solve(dp)   # or "bfs", "gbfs", "ucs"
+if plan is not None:
+    print(plan.cost)            # accumulated total-cost, else action count
+    print(plan.action_names())  # [(name, bindings), ...]
+```
+
+Planner choice: `bfs` (fewest actions), `astar` (goal-count heuristic, optimal
+for unit costs), `gbfs` (greedy, fast), `ucs` (cost-optimal for `:action-costs`
+domains). A planner raises `UnsupportedRequirementsError` if a domain declares
+`:requirements` it does not support.
+
+## Work with states directly
+
+```python
+from pddlpy.planning import State, GroundedTask
+
+task = GroundedTask(dp)
+s = task.initial
+for action, succ in task.successors(s):   # applicable actions + next states
+    ...
+task.is_goal(s)
+s.applicable(op); s.apply(op)              # no manual Atom/tuple casting
+```
+
+## Gotchas
+
+- `initialstate()`/`goals()` return `Atom` objects with **no value equality**.
+  A grounded operator's pre/effects are plain tuples. Normalize with
+  `from pddlpy.planning import atom_tuple` (or compare `repr`s / use `State`).
+- **Type hierarchies (#22):** grounding matches a parameter's declared type
+  exactly — multi-level hierarchies (e.g. logistics) do not fully ground.
+  Untyped (blocksworld) and single-level typed (gripper) domains work.
+- **Durative actions** (`:durative-actions`) parse into `DurativeAction`
+  (`dp.durative_operators()`), but the reference planners are non-temporal and
+  will not solve them.
+- Uppercase keywords (`(:INIT ...)`) are fine — keywords are case-insensitive;
+  identifiers keep their case.
+
+## Commands
+
+```bash
+make            # grammar + python tests
+make coverage   # tests with coverage
+make lint       # ruff
+make typecheck  # mypy
+```
+
+See `docs/object-model.md` for the full model reference.

--- a/tests/test_action_costs.py
+++ b/tests/test_action_costs.py
@@ -3,15 +3,14 @@ import os
 
 from pddlpy import DomainProblem
 from pddlpy.planning import (
-    State,
-    GroundedTask,
+    TOTAL_COST,
     BFSPlanner,
-    AStarPlanner,
+    GroundedTask,
+    State,
     UniformCostPlanner,
     action_cost,
-    plan_cost,
-    TOTAL_COST,
     get,
+    plan_cost,
     registry,
 )
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -68,7 +68,9 @@ def test_uppercase_keywords_parse():
     )
     # initialstate()/goals() hold Atom objects without value equality (#21),
     # so compare by their string (tuple) representation.
-    as_strs = lambda atoms: sorted(str(a) for a in atoms)
+    def as_strs(atoms):
+        return sorted(str(a) for a in atoms)
+
     assert as_strs(upper.initialstate()) == as_strs(lower.initialstate())
     assert as_strs(upper.goals()) == as_strs(lower.goals())
     assert len(upper.initialstate()) == 7

--- a/tests/test_numeric_model.py
+++ b/tests/test_numeric_model.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from pddlpy import DomainProblem
-from pddlpy.pddl import Num, Fluent, BinOp, Neg, NumericConstraint, NumericEffect
+from pddlpy.pddl import BinOp, Fluent, Neg, Num, NumericConstraint, NumericEffect
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
 

--- a/tests/test_numeric_planning.py
+++ b/tests/test_numeric_planning.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from pddlpy import DomainProblem
-from pddlpy.planning import State, GroundedTask, BFSPlanner, AStarPlanner, GBFSPlanner, get
+from pddlpy.planning import AStarPlanner, BFSPlanner, GBFSPlanner, GroundedTask, State
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
 

--- a/tests/test_planner_base.py
+++ b/tests/test_planner_base.py
@@ -7,8 +7,8 @@ from pddlpy import DomainProblem
 from pddlpy.planning import (
     Planner,
     UnsupportedRequirementsError,
-    validate_requirements,
     registry,
+    validate_requirements,
 )
 from pddlpy.planning.base import _used_features
 

--- a/tests/test_planners.py
+++ b/tests/test_planners.py
@@ -5,14 +5,13 @@ import pytest
 
 from pddlpy import DomainProblem
 from pddlpy.planning import (
-    State,
-    GroundedTask,
-    BFSPlanner,
     AStarPlanner,
+    BFSPlanner,
     GBFSPlanner,
+    GroundedTask,
     UnsupportedRequirementsError,
-    registry,
     get,
+    registry,
 )
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")

--- a/tests/test_planning_internals.py
+++ b/tests/test_planning_internals.py
@@ -3,9 +3,9 @@ best-first failure path, and negative-precondition feature detection."""
 import os
 
 from pddlpy import DomainProblem
-from pddlpy.planning import State, Plan, AStarPlanner, GBFSPlanner
-from pddlpy.planning.state import atom_tuple
+from pddlpy.planning import AStarPlanner, GBFSPlanner, Plan, State
 from pddlpy.planning.base import _used_features
+from pddlpy.planning.state import atom_tuple
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -4,7 +4,7 @@ casting."""
 import os
 
 from pddlpy import DomainProblem
-from pddlpy.planning import State, Plan
+from pddlpy.planning import Plan, State
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -17,6 +17,7 @@ def test_no_python2_builtin_import():
     """#16: importing the library must not pull in the py2-only
     `__builtin__` module."""
     import importlib
+
     import pddlpy.pddl as pddl
 
     importlib.reload(pddl)  # exercises the module's imports

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "antlr4-python3-runtime"
@@ -9,6 +13,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/5f/2cdf6f7aca3b20d3f316e9f505292e1f256a32089bd702034c29ebde6242/antlr4_python3_runtime-4.13.2.tar.gz", hash = "sha256:909b647e1d2fc2b70180ac586df3933e38919c85f98ccc656a96cd3f25ef3916", size = 117467, upload-time = "2024-08-03T19:00:12.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl", hash = "sha256:fe3835eb8d33daece0e799090eda89719dbccee7aa39ef94eed3818cafa5a7e8", size = 144462, upload-time = "2024-08-03T19:00:11.134Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -341,7 +385,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -421,6 +465,79 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
+    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +565,66 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41", size = 14691685, upload-time = "2026-05-11T18:33:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/08/9a585dea4325f20d8b80dc78623fa50d1fd2173b710f6237afd6ba6ab39b/mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca", size = 13555165, upload-time = "2026-05-11T18:32:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538", size = 13994376, upload-time = "2026-05-11T18:32:39.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398", size = 14864618, upload-time = "2026-05-11T18:34:49.765Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563", size = 15102063, upload-time = "2026-05-11T18:34:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/40/68/b02dec39057b88eb03dc0aa854732e26e8361f34f9d0e20c7614967d1eba/mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389", size = 11060564, upload-time = "2026-05-11T18:35:36.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a8/ea3dcbef31f99b634f2ee23bb0321cbc8c1b388b76a861eb849f13c347dc/mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666", size = 9966983, upload-time = "2026-05-11T18:37:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -493,6 +670,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "pddlpy"
 version = "0.4.5"
 source = { editable = "." }
@@ -503,8 +689,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "build" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
     { name = "twine" },
 ]
 
@@ -514,8 +702,10 @@ requires-dist = [{ name = "antlr4-python3-runtime", specifier = "==4.13.2" }]
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.0.0" },
+    { name = "mypy", specifier = ">=1.11.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "ruff", specifier = ">=0.6.0" },
     { name = "twine", specifier = ">=5.0.0" },
 ]
 
@@ -658,6 +848,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -742,6 +957,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #74. Adds Python type hints across the package. First of three stacked tooling/docs PRs (#74 → #73 → #72).

## Planning layer (`pddlpy/planning/`)
Fully typed: `State`/`Plan` (with `GroundAtom`/`Valuation` aliases), `GroundedTask`, `Planner` ABC + `PlannerRegistry`, `BFS`/`AStar`/`GBFS`/`UniformCost` planners, and the cost helpers. Uses `from __future__ import annotations` + `TYPE_CHECKING` imports of model types, so **no runtime import is added** and the layer boundary stays intact.

## Object model (`pddlpy/pddl.py`)
Public surface typed: `Atom`, the expression tree (`Expr`/`Num`/`Fluent`/`BinOp`/`Neg`), `NumericConstraint`, `NumericEffect`, `Operator`, `DurativeAction`, and all `DomainProblem` methods. The ANTLR listener internals stay lightly typed (`ctx: Any`) — they're driven by the generated parser API and not worth fighting the type checker over (this is the pragmatic split that #73's mypy config will lean on).

No behavior change; 105 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)