### PR TITLE
#72 — Developers and Agents documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ registry.register('mine', MyPlanner)
 plan = registry.get('mine').solve(dp)
 ```
 
+### Documentation ###
+
+* [`docs/object-model.md`](docs/object-model.md) — full reference for the
+  parser object model and the planning layer.
+* [`skills/pddlpy/SKILL.md`](skills/pddlpy/SKILL.md) — an Agent Skill so coding
+  agents can drive the library (parse, ground, plan).
+
 ### Other Resources ###
 
 There are wonderful material at the the University of Edinburgh:

--- a/docs/object-model.md
+++ b/docs/object-model.md
@@ -1,0 +1,101 @@
+# pddlpy object model
+
+This document describes the object model produced by parsing a PDDL
+domain/problem pair, and the planning layer built on top of it. For a quick
+start see the [README](../README.md); for agent-oriented usage see
+[`skills/pddlpy/SKILL.md`](../skills/pddlpy/SKILL.md).
+
+```
+ANTLR4 grammar -> parse tree -> listener -> object model -> planning layer
+   pddl.g4          (generated)  DomainListener/   DomainProblem    pddlpy.planning
+                                 ProblemListener   Operator/Atom/…
+```
+
+## Layers
+
+| Layer | Module | Depends on |
+|-------|--------|-----------|
+| Grammar / parser | `pddlLexer`, `pddlParser`, `pddlListener` (generated from `pddl.g4`) | — |
+| Object model | `pddlpy.pddl` | grammar |
+| Planning | `pddlpy.planning` | object model only (never the grammar) |
+
+The boundary is enforced by a test: no planning module imports the grammar,
+and the model imports nothing from the planning layer.
+
+## Object model (`pddlpy.pddl`)
+
+### `DomainProblem(domainfile, problemfile)`
+The entry point. Parses both files and exposes:
+
+| Method | Returns |
+|--------|---------|
+| `initialstate()` | set of `Atom` — the problem's initial facts |
+| `goals()` | set of `Atom` — the (positive) goal facts |
+| `operators()` | names of the instantaneous actions |
+| `ground_operator(name)` | iterator of grounded `Operator` instances |
+| `durative_operators()` | names of the durative actions (#23) |
+| `ground_durative_operator(name)` | iterator of grounded `DurativeAction` |
+| `worldobjects()` | `{object: type or None}` |
+| `requirements()` | declared `:requirements` (e.g. `{":strips", ":typing"}`) |
+| `functions()` | `:functions` → ordered `(param, type)` list |
+| `initial_numeric()` | `{ground function head: value}` |
+| `metric()` | `(optimization, expr_text)` or `None` |
+
+### `Atom`
+A predicate applied to terms, e.g. `(on ?x ?y)`. `predicate` is
+`[name, *terms]`; `ground(varvals)` substitutes variables and returns a plain
+tuple. **`Atom` has no value equality** — `initialstate()`/`goals()` hold
+`Atom` objects, while a *grounded* `Operator`'s precondition/effect sets hold
+tuples. Normalize with `pddlpy.planning.atom_tuple` (or compare `repr`s).
+
+### `Operator`
+An instantaneous action, grounded or not. Fields: `operator_name`,
+`variable_list`, `precondition_pos`/`precondition_neg`,
+`precondition_connective` (`'and'`/`'or'`, #13), `effect_pos`/`effect_neg`,
+and the numeric `precondition_num`/`effect_num` (#11).
+
+### Numeric fluents (#11)
+`Expr` tree — `Num`, `Fluent`, `BinOp`, `Neg` — each with
+`ground(varvals)` and `value(valuation)`. `NumericConstraint.holds(valuation)`
+evaluates a numeric precondition; `NumericEffect.apply(valuation)` returns the
+`(head, new_value)` an effect produces.
+
+### `DurativeAction` (#23)
+A durative action with time-tagged `condition_pos`/`condition_neg` keyed by
+`'start'`/`'over'`/`'end'`, `effect_pos`/`effect_neg` keyed by
+`'start'`/`'end'`, and a `duration`. Recovered into the model but **not**
+solved by the reference planners (they are non-temporal).
+
+## Planning layer (`pddlpy.planning`)
+
+- **`State`** — immutable, hashable set of ground atoms plus a numeric fluent
+  valuation. `State.from_problem(dp)`, `state.applicable(op)`,
+  `state.apply(op)`, `state.satisfies(goals)`.
+- **`Plan`** — ordered grounded actions with a `cost`.
+- **`GroundedTask`** — grounds every operator once; `successors(state)` and
+  `is_goal(state)`. Shared by all planners.
+- **`Planner`** ABC — `solve(domainproblem) -> Plan | None`, with a
+  `capabilities` set and fail-fast capability/`:requirements` checks (#9).
+- **`registry`** — register/get planners by name.
+- **Reference planners** — `bfs`, `astar` (goal-count heuristic), `gbfs`,
+  `ucs` (cost-optimal, #3).
+
+```python
+from pddlpy import DomainProblem
+from pddlpy.planning import get
+
+dp = DomainProblem("domain.pddl", "problem.pddl")
+plan = get("astar").solve(dp)
+print(plan.cost, plan.action_names())
+```
+
+## Known limitations
+
+- **Type hierarchies (#22):** grounding matches a parameter's declared type
+  exactly, so multi-level type hierarchies (e.g. logistics) do not fully
+  ground. Single-level typing (gripper) and untyped domains (blocksworld)
+  work.
+- **Disjunctive/ADL preconditions:** the `or` connective is preserved but not
+  evaluated; the reference planners reject such domains via capability checks.
+- **Durative actions:** recovered into the model but not solved (non-temporal
+  planners).

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -18,6 +18,14 @@
 #
 #
 
+"""Core pddlpy object model and PDDL parser glue.
+
+Parses PDDL domain/problem files via the generated ANTLR listeners into a
+``DomainProblem`` exposing the initial state, goals, operators (instantaneous
+and durative), numeric functions and the optimization metric. See
+``docs/object-model.md`` for an overview and ``pddlpy.planning`` for the
+solver layer built on top of this model.
+"""
 from __future__ import annotations
 
 import itertools
@@ -39,6 +47,13 @@ Valuation = Dict[GroundAtom, float]
 
 
 class Atom():
+    """A predicate applied to terms, e.g. ``(on ?x ?y)``.
+
+    ``predicate`` is a sequence ``[name, *terms]``; terms beginning with ``?``
+    are variables. ``ground(varvals)`` substitutes variables and returns a
+    plain tuple. Note: ``Atom`` has no value equality — compare grounded atoms
+    as tuples (see ``pddlpy.planning.atom_tuple``).
+    """
     def __init__(self, predicate: Sequence[str]) -> None:
         self.predicate = predicate
 
@@ -337,6 +352,9 @@ class DurativeAction():
 
 
 class DomainListener(pddlListener):
+    """ANTLR walk listener that builds the domain side of the model: types,
+    constants, predicates, :functions, :requirements, and the (instantaneous
+    and durative) action definitions."""
     def __init__(self):
         self.typesdef = False
         self.objects = {}
@@ -562,6 +580,9 @@ class DomainListener(pddlListener):
 
 
 class ProblemListener(pddlListener):
+    """ANTLR walk listener that builds the problem side of the model: objects,
+    the initial state (symbolic atoms and numeric assignments), the goal, and
+    the optimization metric."""
 
     def __init__(self):
         self.objects = {}

--- a/skills/pddlpy/SKILL.md
+++ b/skills/pddlpy/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: pddlpy
+description: Parse PDDL domain/problem files and solve them with pddlpy. Use when working with PDDL planning files — parsing a domain/problem, inspecting the initial state/goals/operators, grounding actions, evaluating numeric fluents or action costs, or running a reference planner (BFS/A*/GBFS/UCS) to produce a plan.
+---
+
+# pddlpy
+
+`pddlpy` parses PDDL into an object model and solves STRIPS-family problems
+with built-in reference planners. It supports STRIPS, typing, numeric fluents,
+and action costs; durative actions are parsed but not solved.
+
+## Setup
+
+```bash
+uv sync          # install (project uses uv)
+```
+
+Import: `from pddlpy import DomainProblem` and `from pddlpy.planning import get`.
+
+## Parse a domain + problem
+
+```python
+from pddlpy import DomainProblem
+
+dp = DomainProblem("domain.pddl", "problem.pddl")
+dp.initialstate()      # set of Atom (initial facts)
+dp.goals()             # set of Atom (goal facts)
+list(dp.operators())   # action names
+dp.requirements()      # e.g. {":strips", ":typing"}
+dp.functions()         # numeric :functions, if any
+dp.metric()            # ("minimize", "(total-cost)") or None
+```
+
+## Ground an operator
+
+```python
+for op in dp.ground_operator("move"):
+    op.variable_list        # {"?from": "a", "?to": "b"}
+    op.precondition_pos     # set of ground atom tuples
+    op.effect_pos / op.effect_neg
+    op.precondition_num / op.effect_num   # numeric (NumericConstraint / NumericEffect)
+```
+
+## Solve
+
+```python
+from pddlpy.planning import get
+
+plan = get("astar").solve(dp)   # or "bfs", "gbfs", "ucs"
+if plan is not None:
+    print(plan.cost)            # accumulated total-cost, else action count
+    print(plan.action_names())  # [(name, bindings), ...]
+```
+
+Planner choice: `bfs` (fewest actions), `astar` (goal-count heuristic, optimal
+for unit costs), `gbfs` (greedy, fast), `ucs` (cost-optimal for `:action-costs`
+domains). A planner raises `UnsupportedRequirementsError` if a domain declares
+`:requirements` it does not support.
+
+## Work with states directly
+
+```python
+from pddlpy.planning import State, GroundedTask
+
+task = GroundedTask(dp)
+s = task.initial
+for action, succ in task.successors(s):   # applicable actions + next states
+    ...
+task.is_goal(s)
+s.applicable(op); s.apply(op)              # no manual Atom/tuple casting
+```
+
+## Gotchas
+
+- `initialstate()`/`goals()` return `Atom` objects with **no value equality**.
+  A grounded operator's pre/effects are plain tuples. Normalize with
+  `from pddlpy.planning import atom_tuple` (or compare `repr`s / use `State`).
+- **Type hierarchies (#22):** grounding matches a parameter's declared type
+  exactly — multi-level hierarchies (e.g. logistics) do not fully ground.
+  Untyped (blocksworld) and single-level typed (gripper) domains work.
+- **Durative actions** (`:durative-actions`) parse into `DurativeAction`
+  (`dp.durative_operators()`), but the reference planners are non-temporal and
+  will not solve them.
+- Uppercase keywords (`(:INIT ...)`) are fine — keywords are case-insensitive;
+  identifiers keep their case.
+
+## Commands
+
+```bash
+make            # grammar + python tests
+make coverage   # tests with coverage
+make lint       # ruff
+make typecheck  # mypy
+```
+
+See `docs/object-model.md` for the full model reference.


### PR DESCRIPTION
Closes #72. Documentation for developers and agents. **Stacked on #73** (`lint-mypy-73`) — review/merge that first. Last of the three stacked PRs.

## What's here
- **`docs/object-model.md`** — full reference: the grammar→model→planning layering and its enforced boundary, the `DomainProblem` API table, `Atom`/`Operator`, numeric fluents (`Expr`/`NumericConstraint`/`NumericEffect`), `DurativeAction`, the planning layer (`State`/`Plan`/`GroundedTask`/`Planner`/registry/planners), and known limitations (#22 type hierarchies, disjunctive/ADL, durative non-coverage).
- **`skills/pddlpy/SKILL.md`** — an Agent Skill (name + description frontmatter) so coding agents can drive the library: parse, inspect, ground, evaluate numeric/cost, and run a planner, with the key gotchas (Atom vs tuple, type-hierarchy limit, durative non-coverage, case-insensitive keywords). Committed under `skills/` because `.claude/` is gitignored.
- Filled docstring gaps: module docstring for `pddl.py`, plus `Atom` and the two listener classes.
- README now links to both docs.

## Notes
- The `docstrings` / `object model documentation` / `SKILL` checklist items in #72 are all covered.
- `docs/` and `skills/` are repo artifacts and are not packaged into the wheel (the build `only-include` list is unchanged).

ruff + mypy clean; 105 tests pass; coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)