### PR TITLE
#22: support type super-sets in grounding

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -112,7 +112,10 @@ numbers link to GitHub. Do not start a later phase until the prior phase's tests
 ## Backlog / decisions
 - [ ] **#10 — ADL** (conditional effects, quantifiers) — schedule after #13's precondition tree.
 - [ ] **#12 — better variable binding** — revisit once grounding (#26) is fixed; may be subsumed.
-- [ ] **#22 — type super-sets** — typing hierarchy enhancement; Phase 2-ish.
+- [x] **#22 — type super-sets** — typing hierarchy enhancement; Phase 2-ish. *Capture the
+      `:types` subtype→supertype map (`DomainProblem.types()`/`subtypes_of()`); subtype-aware
+      grounding (`_is_subtype`) so a supertype-typed param binds objects of any transitive
+      subtype. logistics now grounds + solves. `(either ...)` union types still unhandled.*
 - [ ] **#35 — HDDL parser** — decided **out of scope** (PRD §4). Reply and close.
 
 ## Done / merged

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -358,6 +358,9 @@ class DomainListener(pddlListener):
     def __init__(self):
         self.typesdef = False
         self.objects = {}
+        # type hierarchy: maps each declared subtype to its direct supertype
+        # (#22). E.g. (:types airport - location) yields {'airport': 'location'}.
+        self.types = {}
         self.operators = {}
         self.durative_operators = {}
         self.scopes = []
@@ -456,7 +459,11 @@ class DomainListener(pddlListener):
 
     def exitTypesDef(self, ctx):
         self.typesdef = True
-        self.scopes.pop()
+        # Keep the subtype -> supertype map (#22) instead of discarding it. The
+        # Obj scope collected it as variable_list via enterTypedNameList; a type
+        # with no declared parent maps to None.
+        scope = self.scopes.pop()
+        self.types = dict(scope.variable_list)
 
     def enterTypedVariableList(self, ctx):
         # print("-> tvar")
@@ -766,8 +773,53 @@ class DomainProblem():
         for ground in self._instantiate( op_name ):
             yield op.ground( dict(ground) )
 
+    def _is_subtype(self, ot, t):
+        """True if object-type ``ot`` satisfies a parameter typed ``t`` (#22):
+        either they are equal or ``ot`` is a transitive subtype of ``t``. The
+        equality check comes first so untyped domains (``None == None``) and
+        flat-typed domains keep working unchanged.
+        """
+        # An untyped parameter (t is None) binds only untyped objects, matching
+        # the original exact-match behaviour; do not let a typed object climb to
+        # the implicit None root and match an untyped parameter.
+        if t is None:
+            return ot is None
+        seen = set()
+        while ot is not None and ot not in seen:
+            if ot == t:
+                return True
+            seen.add(ot)
+            ot = self.domain.types.get(ot)
+        return False
+
     def _typesymbols(self, t):
-        return ( k for k,v in self.worldobjects().items() if v == t )
+        return ( k for k,v in self.worldobjects().items() if self._is_subtype(v, t) )
+
+    def types(self) -> Dict[str, Optional[str]]:
+        """Returns the declared type hierarchy as a dict mapping each subtype to
+        its direct supertype (#22), e.g. ``{'airport': 'location', 'location':
+        'object'}``. A type with no declared parent maps to ``None``. Empty if
+        the domain declares no ``:types``.
+        """
+        return dict(self.domain.types)
+
+    def subtypes_of(self, t: str) -> set:
+        """Returns the set of all transitive subtypes of ``t`` (#22), excluding
+        ``t`` itself. E.g. for the logistics hierarchy ``subtypes_of('physobj')``
+        is ``{'package', 'vehicle', 'truck', 'airplane'}``.
+        """
+        hierarchy = self.domain.types
+        result = set()
+        changed = True
+        while changed:
+            changed = False
+            for sub, sup in hierarchy.items():
+                if sub in result:
+                    continue
+                if sup == t or sup in result:
+                    result.add(sub)
+                    changed = True
+        return result
 
     def _set_operator_groundspace(self, opname, variables):
         # cache the variables ground space for each operator.

--- a/tests/test_type_hierarchy.py
+++ b/tests/test_type_hierarchy.py
@@ -1,0 +1,153 @@
+"""#22 type super-sets: the declared :types hierarchy is captured, a parameter
+typed with a supertype binds objects of any (transitive) subtype, and the
+hierarchy is exposed via the API.
+"""
+import os
+
+from pddlpy import DomainProblem
+from pddlpy.planning import BFSPlanner, GroundedTask
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _dp(name):
+    return DomainProblem(
+        os.path.join(CORPUS, "%s-domain.pddl" % name),
+        os.path.join(CORPUS, "%s-problem.pddl" % name),
+    )
+
+
+# -- hierarchy is captured & exposed ------------------------------------------
+
+def test_type_map_captured():
+    dp = _dp("logistics")
+    assert dp.types() == {
+        "truck": "vehicle",
+        "airplane": "vehicle",
+        "package": "physobj",
+        "vehicle": "physobj",
+        "airport": "location",
+        "city": "object",
+        "location": "object",
+        "physobj": "object",
+    }
+
+
+def test_subtypes_of_transitive():
+    dp = _dp("logistics")
+    assert dp.subtypes_of("object") == {
+        "truck", "airplane", "package", "vehicle",
+        "airport", "city", "location", "physobj",
+    }
+    assert dp.subtypes_of("physobj") == {"truck", "airplane", "package", "vehicle"}
+    assert dp.subtypes_of("vehicle") == {"truck", "airplane"}
+    assert dp.subtypes_of("location") == {"airport"}
+
+
+def test_subtypes_of_leaf_and_unknown():
+    dp = _dp("logistics")
+    assert dp.subtypes_of("truck") == set()   # leaf type
+    assert dp.subtypes_of("nonsuch") == set()  # undeclared type
+
+
+# -- supertype parameters bind subtype objects (the core fix) -----------------
+
+def test_supertype_param_binds_subtype_objects():
+    dp = _dp("logistics")
+    grounds = list(dp.ground_operator("drive-truck"))
+    # ?loc-from / ?loc-to are typed `location`; objects are airports + locations.
+    locs = {op.variable_list["?loc-from"] for op in grounds}
+    assert locs == {"apt1", "apt2", "pos1", "pos2"}
+    # full cartesian: 2 trucks * 4 locs * 4 locs * 2 cities
+    assert len(grounds) == 64
+
+
+def test_logistics_solvable_end_to_end():
+    # Previously impossible: a `location` parameter never bound `airport`
+    # objects, so the operators ground to nothing (the CLAUDE.md Known Issue).
+    dp = _dp("logistics")
+    plan = BFSPlanner().solve(dp)
+    assert plan is not None and len(plan) > 0
+    task = GroundedTask(dp)
+    state = task.initial
+    for action in plan:
+        assert state.applicable(action)
+        state = state.apply(action)
+    assert task.is_goal(state)
+
+
+def test_bartender_hierarchy_grounds(tmp_path):
+    # The multi-level hierarchy from issue #22.
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(
+        "(define (domain bar)\n"
+        " (:requirements :strips :typing)\n"
+        " (:types ingredient cocktail - beverage\n"
+        "         shot shaker - container\n"
+        "         beverage container - object)\n"
+        " (:predicates (holds ?c - container ?b - beverage) (clean ?c - container))\n"
+        " (:action pour :parameters (?c - container ?b - beverage)\n"
+        "   :precondition (clean ?c) :effect (holds ?c ?b)))\n"
+    )
+    problem.write_text(
+        "(define (problem p) (:domain bar)\n"
+        " (:objects sh1 - shot shk1 - shaker rum - ingredient mojito - cocktail)\n"
+        " (:init (clean sh1) (clean shk1))\n"
+        " (:goal (and (holds sh1 rum))))\n"
+    )
+    dp = DomainProblem(str(domain), str(problem))
+    grounds = list(dp.ground_operator("pour"))
+    containers = {op.variable_list["?c"] for op in grounds}
+    beverages = {op.variable_list["?b"] for op in grounds}
+    assert containers == {"sh1", "shk1"}            # both container subtypes
+    assert beverages == {"rum", "mojito"}           # both beverage subtypes
+    assert len(grounds) == 4
+
+
+# -- regressions: flat-typed and untyped grounding must not change ------------
+
+def test_flat_typing_unchanged():
+    dp = _dp("gripper")
+    # gripper's `move` over rooms still grounds to the same non-empty set.
+    grounds = list(dp.ground_operator("move"))
+    assert len(grounds) > 0
+
+
+def test_untyped_grounding_unchanged(tmp_path):
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(
+        "(define (domain d) (:requirements :strips) (:predicates (p ?x))\n"
+        " (:action a :parameters (?x) :precondition (p ?x) :effect (not (p ?x))))"
+    )
+    problem.write_text(
+        "(define (problem p) (:domain d) (:objects o1 o2)\n"
+        " (:init (p o1) (p o2)) (:goal (and (p o1))))"
+    )
+    dp = DomainProblem(str(domain), str(problem))
+    grounds = list(dp.ground_operator("a"))
+    # Untyped param binds the untyped objects exactly as before (the parser also
+    # surfaces atom symbols as untyped objects, a pre-existing quirk; the point
+    # here is that o1/o2 still bind and nothing typed leaks in).
+    assert {"o1", "o2"} <= {op.variable_list["?x"] for op in grounds}
+
+
+# -- _is_subtype edge cases ---------------------------------------------------
+
+def test_is_subtype_edges():
+    dp = _dp("logistics")
+    assert dp._is_subtype("truck", "truck") is True       # equal
+    assert dp._is_subtype("truck", "physobj") is True      # transitive
+    assert dp._is_subtype("truck", "object") is True       # to root
+    assert dp._is_subtype("truck", "location") is False    # unrelated branch
+    assert dp._is_subtype(None, None) is True              # untyped param/object
+    assert dp._is_subtype(None, "object") is False         # untyped object, typed param
+    assert dp._is_subtype("airport", None) is False        # typed object, untyped param
+
+
+def test_is_subtype_cycle_terminates():
+    dp = _dp("logistics")
+    # A malformed cyclic hierarchy must not loop forever.
+    dp.domain.types = {"a": "b", "b": "a"}
+    assert dp._is_subtype("a", "z") is False


### PR DESCRIPTION
## Summary
Resolves #22. The `:types` hierarchy was parsed and then **discarded**, and grounding matched object types by exact equality — so a parameter typed with a supertype (e.g. `location`) never bound objects of a subtype (e.g. `airport`), and hierarchical domains like IPC logistics parsed but could not ground or solve (the CLAUDE.md "Known Issue").

This PR:
- **Captures the hierarchy** in `DomainListener.exitTypesDef` as a subtype→supertype map (was thrown away).
- **Subtype-aware grounding**: new `DomainProblem._is_subtype(ot, t)` (equality, else walk up the hierarchy) replaces the exact-match `_typesymbols`. Equality-first keeps untyped (`None`) and flat-typed domains unchanged.
- **Hierarchy API** (the literal ask in #22): `DomainProblem.types()` → child→parent map; `DomainProblem.subtypes_of(t)` → transitive subtypes.

`(either t1 t2)` union parameter types remain unhandled (out of scope, noted).

## Result
IPC logistics now grounds and BFS-solves end-to-end (12-step plan); `drive-truck` binds both `airport` and `location` objects.

## Tests
New `tests/test_type_hierarchy.py` (hierarchy capture, transitive `subtypes_of`, supertype params binding subtype objects, logistics solve, the bartender multi-level fixture from the issue, untyped/flat-typed regressions, `_is_subtype` None/cycle edges). Full suite green (115 passed); `pddlpy/pddl.py` stays at **100%** line coverage; ruff + mypy clean.

## Note for reviewers
This is **PR 1 of 2**. A stacked follow-up implements #12 (pluggable, precondition-pruned variable binding) on top of this subtype-aware grounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)