### PR TITLE
#12: pluggable, static-pruned variable binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,42 @@ You can also read the domain's declared requirements:
 {':strips', ':typing'}
 ```
 
+#### Type hierarchies and variable binding
+
+A `:types` hierarchy (e.g. `airport - location`, `location - object`) is
+honoured: a parameter typed with a supertype binds objects of any transitive
+subtype, so multi-level domains such as logistics ground and solve. The
+hierarchy is also exposed directly:
+
+```python
+>>> domprob.types()          # subtype -> direct supertype
+{'airport': 'location', 'location': 'object', ...}
+>>> domprob.subtypes_of('object')   # all transitive subtypes
+{'location', 'airport', ...}
+```
+
+Grounding is performed by a pluggable variable **binder**. The default
+`StaticPrunedBinder` prunes parameter bindings that can never be applicable by
+joining the operator's *static* preconditions (predicates no action ever
+modifies) against the initial state — sound, since a static predicate's truth
+is fixed for the whole search. Pass `binder=CartesianBinder()` for the plain
+full product, or supply your own:
+
+```python
+from pddlpy import DomainProblem
+from pddlpy.binding import CartesianBinder, VariableBinder
+
+dp = DomainProblem('domain.pddl', 'problem.pddl', binder=CartesianBinder())
+
+class MyBinder(VariableBinder):
+    def bind(self, dp, operator):
+        # yield {param_name: object_name} dicts; helpers: dp.candidate_objects(t),
+        # dp.static_predicates(), dp.initialstate(), dp.worldobjects()
+        ...
+
+dp.binder = MyBinder()
+```
+
 ### Planning API ###
 
 Above the parser/object model sits an optional, strictly-layered planning

--- a/TODO.md
+++ b/TODO.md
@@ -111,7 +111,14 @@ numbers link to GitHub. Do not start a later phase until the prior phase's tests
 
 ## Backlog / decisions
 - [ ] **#10 — ADL** (conditional effects, quantifiers) — schedule after #13's precondition tree.
-- [ ] **#12 — better variable binding** — revisit once grounding (#26) is fixed; may be subsumed.
+- [x] **#12 — better variable binding** — revisit once grounding (#26) is fixed; may be subsumed.
+      *Factored grounding behind a pluggable `VariableBinder` (`pddlpy/binding.py`): default
+      `StaticPrunedBinder` joins static positive preconditions against the initial state (sound:
+      static predicates never change) and filters static negatives, yielding a subset of the
+      cartesian bindings — e.g. logistics `drive-truck` 16 vs 64. `CartesianBinder` keeps the
+      full product; users pass `binder=` or set `dp.binder`. Disjunctive preconditions fall back
+      to cartesian. Retires the per-operator `vargroundspace` cache. Builds on #22's subtype-aware
+      candidates.*
 - [x] **#22 — type super-sets** — typing hierarchy enhancement; Phase 2-ish. *Capture the
       `:types` subtype→supertype map (`DomainProblem.types()`/`subtypes_of()`); subtype-aware
       grounding (`_is_subtype`) so a supertype-typed param binds objects of any transitive

--- a/pddlpy/binding.py
+++ b/pddlpy/binding.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright 2015 Hernán M. Foffani
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Variable binding strategies for operator grounding (#12).
+
+Grounding an operator means enumerating the value assignments for its
+parameters. The historical strategy was a blind cartesian product over each
+parameter's type-compatible objects, which does not scale and offered no way
+to customise it.
+
+This module factors binding out behind the :class:`VariableBinder` interface so
+it can be swapped or overridden:
+
+- :class:`CartesianBinder` reproduces the original full product.
+- :class:`StaticPrunedBinder` (the default) prunes assignments that can never be
+  applicable by joining the operator's *static* positive preconditions against
+  the initial state — sound, because a static predicate (one no action ever
+  modifies) has the same truth value in every reachable state as in the initial
+  state. It never drops a genuinely applicable grounding.
+
+Binders are stateless and receive the ``DomainProblem`` plus the lifted operator
+on each call, so there is no cross-operator caching to get wrong (#26).
+
+A custom binder only needs to implement ``bind(dp, operator)`` and yield
+``{param: object}`` dicts; useful ``DomainProblem`` helpers are
+``candidate_objects(type)``, ``worldobjects()``, ``initialstate()`` and
+``static_predicates()``.
+"""
+from __future__ import annotations
+
+import itertools
+from abc import ABC, abstractmethod
+from typing import Dict, Iterator, List, Optional
+
+
+class VariableBinder(ABC):
+    """Strategy that enumerates parameter bindings for an operator (#12)."""
+
+    @abstractmethod
+    def bind(self, dp, operator) -> Iterator[Dict[str, str]]:
+        """Yield ``{param_name: object_name}`` assignments, one per grounding.
+
+        dp        -- the DomainProblem being grounded.
+        operator  -- the lifted Operator whose ``variable_list`` maps each
+                     parameter to its declared type (or None if untyped).
+        """
+        raise NotImplementedError  # pragma: no cover - abstract
+
+
+class CartesianBinder(VariableBinder):
+    """Full cartesian product of each parameter over its type-compatible
+    objects — the original (subtype-aware, #22) behaviour, with no pruning."""
+
+    def bind(self, dp, operator) -> Iterator[Dict[str, str]]:
+        params = list(operator.variable_list.items())
+        domains = [dp.candidate_objects(t) for _, t in params]
+        names = [name for name, _ in params]
+        for combo in itertools.product(*domains):
+            yield dict(zip(names, combo))
+
+
+class StaticPrunedBinder(VariableBinder):
+    """Default binder: prune bindings using static preconditions (#12).
+
+    Positive precondition atoms over static predicates are joined against the
+    initial state (each variable additionally type-checked), so only bindings
+    that satisfy them are generated; the remaining free parameters expand over
+    their type domain. Negative static preconditions filter out bindings whose
+    atom is present in the initial state. This yields a subset of the cartesian
+    bindings, dropping only ones that can never be applicable.
+    """
+
+    def bind(self, dp, operator) -> Iterator[Dict[str, str]]:
+        # Pruning assumes the positive preconditions must all hold (a
+        # conjunction). For a disjunctive precondition (#13) the flattened atoms
+        # are alternatives, not conjuncts, so static joining would be unsound —
+        # fall back to the full cartesian product.
+        if operator.precondition_connective != 'and':
+            yield from CartesianBinder().bind(dp, operator)
+            return
+
+        static = dp.static_predicates()
+        init = {a.ground({}) for a in dp.initialstate()}
+        objtype = dp.worldobjects()
+
+        pos = [a for a in operator.precondition_pos if a.predicate[0] in static]
+        neg = [a for a in operator.precondition_neg if a.predicate[0] in static]
+
+        # Seed with the empty assignment, then join each static positive atom
+        # against matching initial-state tuples.
+        partials: List[Dict[str, str]] = [{}]
+        for atom in pos:
+            pattern = atom.predicate
+            name = pattern[0]
+            candidates = [t for t in init
+                          if t[0] == name and len(t) == len(pattern)]
+            nxt: List[Dict[str, str]] = []
+            for partial in partials:
+                for tup in candidates:
+                    merged = self._unify(partial, pattern, tup, operator, dp, objtype)
+                    if merged is not None:
+                        nxt.append(merged)
+            partials = nxt
+            if not partials:
+                return  # a static positive precondition is unsatisfiable
+
+        names = list(operator.variable_list.keys())
+        for partial in partials:
+            free = [v for v in names if v not in partial]
+            domains = [dp.candidate_objects(operator.variable_list[v]) for v in free]
+            for combo in itertools.product(*domains):
+                full = dict(partial)
+                full.update(zip(free, combo))
+                if any(a.ground(full) in init for a in neg):
+                    continue  # a static negative precondition is violated
+                yield full
+
+    @staticmethod
+    def _unify(partial, pattern, tup, operator, dp, objtype) -> Optional[Dict[str, str]]:
+        """Extend ``partial`` by matching atom ``pattern`` to init tuple ``tup``.
+
+        Returns the merged assignment, or None on a conflict: a constant
+        mismatch, a variable rebound to a different value, or a value whose type
+        is not compatible with the parameter's declared type.
+        """
+        merged = dict(partial)
+        for sym, val in zip(pattern[1:], tup[1:]):
+            if sym.startswith('?'):
+                if not dp._is_subtype(objtype.get(val), operator.variable_list[sym]):
+                    return None
+                if merged.get(sym, val) != val:
+                    return None
+                merged[sym] = val
+            elif sym != val:
+                return None  # constant in the precondition must match
+        return merged

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -28,12 +28,12 @@ solver layer built on top of this model.
 """
 from __future__ import annotations
 
-import itertools
 import operator as _operator
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, cast
 
 from antlr4 import CommonTokenStream, FileStream, ParseTreeWalker
 
+from .binding import CartesianBinder, StaticPrunedBinder, VariableBinder
 from .pddlLexer import pddlLexer
 from .pddlListener import pddlListener
 from .pddlParser import pddlParser
@@ -366,6 +366,7 @@ class DomainListener(pddlListener):
         self.scopes = []
         self.negativescopes = []
         self.requirements = set()
+        self.predicates = set()  # declared predicate names (#12)
         self.functions = {}
         self._datimes = []      # stack of current 'start'/'over'/'end' tags
 
@@ -453,6 +454,11 @@ class DomainListener(pddlListener):
 
     def exitPredicatesDef(self, ctx):
         self.scopes.pop()
+
+    def enterAtomicFormulaSkeleton(self, ctx):
+        # Record each declared predicate name (#12): a predicate that no action
+        # ever modifies is static, which lets the grounder prune bindings.
+        self.predicates.add(ctx.predicate().getText())
 
     def enterTypesDef(self, ctx):
         self.scopes.append(Obj())
@@ -674,12 +680,16 @@ class ProblemListener(pddlListener):
 
 class DomainProblem():
 
-    def __init__(self, domainfile: str, problemfile: str) -> None:
+    def __init__(self, domainfile: str, problemfile: str,
+                 binder: Optional[VariableBinder] = None) -> None:
         """Parses a PDDL domain and problem files and
         returns an object representing them.
 
         domainfile -- path for the PDDL domain file
         problemfile -- path for the PDDL problem file
+        binder -- variable binding strategy for ground_operator (#12); defaults
+                  to StaticPrunedBinder. Pass a custom VariableBinder, or set
+                  the .binder attribute later, to override grounding.
         """
         # domain
         inp = FileStream(domainfile)
@@ -699,11 +709,8 @@ class DomainProblem():
         self.problem = ProblemListener()
         walker = ParseTreeWalker()
         walker.walk(self.problem, tree)
-        # variable ground space for each operator.
-        # a dict where keys are op names and values
-        # a dict where keys are var names and values
-        # a list of possible symbols.
-        self.vargroundspace: Dict[str, Dict[str, List[str]]] = {}
+        # Variable binding strategy used by ground_operator (#12).
+        self.binder: VariableBinder = binder if binder is not None else StaticPrunedBinder()
 
     def operators(self) -> Any:
         """Returns an iterator of the names of the (instantaneous) actions
@@ -751,12 +758,10 @@ class DomainProblem():
         returns -- An iterator of Operator instances.
         """
         op = self.domain.operators[op_name]
-        self._set_operator_groundspace( op_name, op.variable_list.items() )
-        for ground in self._instantiate( op_name ):
-            # print('grounded', ground)
-            st = dict(ground)
+        for st in self.binder.bind( self, op ):
             gop = Operator(op_name)
-            gop.variable_list = st
+            # grounded values are object names; widen to the field's lifted type
+            gop.variable_list = cast(Dict[str, Optional[str]], st)
             gop.precondition_connective = op.precondition_connective
             gop.precondition_pos = set( [ a.ground( st ) for a in op.precondition_pos ] )
             gop.precondition_neg = set( [ a.ground( st ) for a in op.precondition_neg ] )
@@ -767,11 +772,14 @@ class DomainProblem():
             yield gop
 
     def ground_durative_operator(self, op_name: str) -> Iterator[DurativeAction]:
-        """Returns an iterator of grounded DurativeAction instances (#23)."""
+        """Returns an iterator of grounded DurativeAction instances (#23).
+
+        Durative actions always use the cartesian binder: their conditions are
+        time-tagged and static-precondition pruning does not apply.
+        """
         op = self.domain.durative_operators[op_name]
-        self._set_operator_groundspace( op_name, op.variable_list.items() )
-        for ground in self._instantiate( op_name ):
-            yield op.ground( dict(ground) )
+        for st in CartesianBinder().bind( self, op ):
+            yield op.ground( st )
 
     def _is_subtype(self, ot, t):
         """True if object-type ``ot`` satisfies a parameter typed ``t`` (#22):
@@ -792,8 +800,28 @@ class DomainProblem():
             ot = self.domain.types.get(ot)
         return False
 
-    def _typesymbols(self, t):
-        return ( k for k,v in self.worldobjects().items() if self._is_subtype(v, t) )
+    def candidate_objects(self, t) -> List[str]:
+        """Returns the objects that can bind a parameter of type ``t``: any
+        object whose type is ``t`` or a (transitive) subtype of it (#22).
+        Used by the variable binders (#12).
+        """
+        return [ k for k,v in self.worldobjects().items() if self._is_subtype(v, t) ]
+
+    def static_predicates(self) -> set:
+        """Returns the set of static predicate names (#12): predicates declared
+        in the domain that no action (instantaneous or durative) ever adds or
+        deletes. Their truth is fixed by the initial state, so the grounder can
+        use them to prune bindings that can never become applicable.
+        """
+        modified = set()
+        for op in self.domain.operators.values():
+            for a in op.effect_pos | op.effect_neg:
+                modified.add(a.predicate[0])
+        for da in self.domain.durative_operators.values():
+            for time in da.EFFECT_TIMES:
+                for a in da.effect_pos[time] | da.effect_neg[time]:
+                    modified.add(a.predicate[0])
+        return set(self.domain.predicates) - modified
 
     def types(self) -> Dict[str, Optional[str]]:
         """Returns the declared type hierarchy as a dict mapping each subtype to
@@ -820,22 +848,6 @@ class DomainProblem():
                     result.add(sub)
                     changed = True
         return result
-
-    def _set_operator_groundspace(self, opname, variables):
-        # cache the variables ground space for each operator.
-        if opname not in self.vargroundspace:
-            d = self.vargroundspace.setdefault(opname, {})
-            for vname, t in variables:
-                for symb in self._typesymbols(t):
-                    d.setdefault(vname, []).append(symb)
-
-    def _instantiate(self, opname):
-        d = self.vargroundspace[opname]
-        # expands the dict to something like:
-        #[ [('?x1','A'),('?x1','B')..], [('?x2','M'),('?x2','N')..],..]
-        expanded = [ [ (vname, symb) for symb in d[vname] ] for vname in d ]
-        # cartesian product.
-        return itertools.product(*expanded)
 
     def initialstate(self) -> set:
         """Returns a set of atoms (Atom objects) corresponding to the initial

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,0 +1,189 @@
+"""#12 better variable binding: the default StaticPrunedBinder prunes bindings
+that can never be applicable (via static preconditions) while remaining sound,
+the CartesianBinder reproduces the full product, and binders are pluggable.
+"""
+import os
+
+from pddlpy import DomainProblem
+from pddlpy.binding import CartesianBinder, StaticPrunedBinder, VariableBinder
+from pddlpy.planning import BFSPlanner, GroundedTask
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _dp(name, **kw):
+    return DomainProblem(
+        os.path.join(CORPUS, "%s-domain.pddl" % name),
+        os.path.join(CORPUS, "%s-problem.pddl" % name),
+        **kw,
+    )
+
+
+def _binds(grounds):
+    return {tuple(sorted(op.variable_list.items())) for op in grounds}
+
+
+# -- pruning is a sound subset of the cartesian product -----------------------
+
+def test_pruned_is_strict_subset_of_cartesian():
+    pruned = list(_dp("logistics").ground_operator("drive-truck"))
+    cart = list(_dp("logistics", binder=CartesianBinder()).ground_operator("drive-truck"))
+    assert len(pruned) < len(cart)            # actually pruned (16 vs 64)
+    assert _binds(pruned) < _binds(cart)      # and a strict subset
+
+
+def test_dropped_bindings_are_never_applicable():
+    # Every cartesian binding the pruner drops is genuinely inapplicable in the
+    # initial state — the soundness guarantee.
+    dp = _dp("logistics")
+    task = GroundedTask(dp)  # grounded with the default pruned binder
+    init = task.initial
+    pruned = _binds(dp.ground_operator("drive-truck"))
+    cart = list(_dp("logistics", binder=CartesianBinder()).ground_operator("drive-truck"))
+    dropped = [op for op in cart
+               if tuple(sorted(op.variable_list.items())) not in pruned]
+    assert dropped
+    for op in dropped:
+        assert not init.applicable(op)
+
+
+def test_pruned_and_cartesian_solve_identically():
+    for name in ("blocksworld", "gripper", "logistics"):
+        pruned_plan = BFSPlanner().solve(_dp(name))
+        cart_plan = BFSPlanner().solve(_dp(name, binder=CartesianBinder()))
+        assert pruned_plan is not None and cart_plan is not None
+        assert len(pruned_plan) == len(cart_plan)
+
+
+# -- static_predicates --------------------------------------------------------
+
+def test_static_predicates_logistics():
+    # in-city never appears in an effect; at/in do.
+    assert _dp("logistics").static_predicates() == {"in-city"}
+
+
+def test_static_predicates_includes_durative_effects():
+    # Exercises the durative-effect branch: predicates modified by a durative
+    # action are not static.
+    dp = DomainProblem(
+        os.path.join(CORPUS, "durative-action-domain.pddl"),
+        os.path.join(CORPUS, "durative-action-problem.pddl"),
+    )
+    static = dp.static_predicates()
+    modified = set()
+    for da in dp.domain.durative_operators.values():
+        for t in da.EFFECT_TIMES:
+            for a in da.effect_pos[t] | da.effect_neg[t]:
+                modified.add(a.predicate[0])
+    assert static.isdisjoint(modified)
+
+
+# -- pluggability -------------------------------------------------------------
+
+def test_custom_binder_is_used():
+    calls = []
+
+    class OneBinder(VariableBinder):
+        def bind(self, dp, operator):
+            calls.append(operator.operator_name)
+            yield {v: "x" for v in operator.variable_list}
+
+    dp = _dp("gripper", binder=OneBinder())
+    grounds = list(dp.ground_operator("move"))
+    assert len(grounds) == 1
+    assert calls == ["move"]
+    # also settable after construction
+    dp2 = _dp("gripper")
+    dp2.binder = OneBinder()
+    assert len(list(dp2.ground_operator("move"))) == 1
+
+
+def test_default_binder_is_static_pruned():
+    assert isinstance(_dp("gripper").binder, StaticPrunedBinder)
+
+
+# -- branch coverage on small hand-built domains ------------------------------
+
+def _make(tmp_path, domain_text, problem_text):
+    d = tmp_path / "d.pddl"
+    p = tmp_path / "p.pddl"
+    d.write_text(domain_text)
+    p.write_text(problem_text)
+    return DomainProblem(str(d), str(p))
+
+
+def test_disjunctive_precondition_not_pruned(tmp_path):
+    # (or ...) falls back to cartesian; q is static and absent from init but the
+    # binding is still produced (consuming the full generator covers the return).
+    dp = _make(
+        tmp_path,
+        "(define (domain d) (:requirements :strips :disjunctive-preconditions)\n"
+        " (:predicates (p ?x) (q ?x))\n"
+        " (:action a :parameters (?x) :precondition (or (p ?x) (q ?x))\n"
+        "   :effect (not (p ?x))))",
+        "(define (problem p) (:domain d) (:objects o1 o2)\n"
+        " (:init (p o1)) (:goal (and (p o1))))",
+    )
+    grounds = list(dp.ground_operator("a"))
+    assert {op.variable_list["?x"] for op in grounds} >= {"o1", "o2"}
+
+
+def test_unsatisfiable_static_precondition_yields_nothing(tmp_path):
+    # s is static and there are no s facts in init -> no grounding can apply.
+    dp = _make(
+        tmp_path,
+        "(define (domain d) (:requirements :strips)\n"
+        " (:predicates (s ?x) (done ?x))\n"
+        " (:action a :parameters (?x) :precondition (s ?x) :effect (done ?x)))",
+        "(define (problem p) (:domain d) (:objects o1 o2)\n"
+        " (:init (done o1)) (:goal (and (done o1))))",
+    )
+    assert list(dp.ground_operator("a")) == []
+
+
+def test_negative_static_precondition_filters(tmp_path):
+    # blocked is static; (not (blocked ?x)) drops o1 but keeps o2.
+    dp = _make(
+        tmp_path,
+        "(define (domain d) (:requirements :strips :negative-preconditions)\n"
+        " (:predicates (free ?x) (blocked ?x) (done ?x))\n"
+        " (:action a :parameters (?x)\n"
+        "   :precondition (and (free ?x) (not (blocked ?x))) :effect (done ?x)))",
+        "(define (problem p) (:domain d) (:objects o1 o2)\n"
+        " (:init (free o1) (free o2) (blocked o1)) (:goal (and (done o2))))",
+    )
+    grounds = list(dp.ground_operator("a"))
+    assert {op.variable_list["?x"] for op in grounds} == {"o2"}
+
+
+def test_type_incompatible_init_binding_rejected(tmp_path):
+    # holds is static; init applies it to a box, but the parameter is an item,
+    # so that join candidate is rejected on the type check.
+    dp = _make(
+        tmp_path,
+        "(define (domain d) (:requirements :strips :typing)\n"
+        " (:types item box)\n"
+        " (:predicates (holds ?i - item) (modi ?i - item))\n"
+        " (:action a :parameters (?i - item) :precondition (holds ?i)\n"
+        "   :effect (modi ?i)))",
+        "(define (problem p) (:domain d) (:objects it1 - item bx1 - box)\n"
+        " (:init (holds it1) (holds bx1)) (:goal (and (modi it1))))",
+    )
+    grounds = list(dp.ground_operator("a"))
+    assert {op.variable_list["?i"] for op in grounds} == {"it1"}
+
+
+def test_constant_in_static_precondition(tmp_path):
+    # at is static and references the constant `home`; only objects at home bind.
+    dp = _make(
+        tmp_path,
+        "(define (domain d) (:requirements :strips :typing)\n"
+        " (:types loc obj) (:constants home - loc)\n"
+        " (:predicates (at ?o - obj ?l - loc) (moved ?o - obj))\n"
+        " (:action a :parameters (?o - obj) :precondition (at ?o home)\n"
+        "   :effect (moved ?o)))",
+        "(define (problem p) (:domain d) (:objects o1 o2 - obj away - loc)\n"
+        " (:init (at o1 home) (at o2 away)) (:goal (and (moved o1))))",
+    )
+    grounds = list(dp.ground_operator("a"))
+    assert {op.variable_list["?o"] for op in grounds} == {"o1"}

--- a/tests/test_type_hierarchy.py
+++ b/tests/test_type_hierarchy.py
@@ -5,6 +5,7 @@ hierarchy is exposed via the API.
 import os
 
 from pddlpy import DomainProblem
+from pddlpy.binding import CartesianBinder
 from pddlpy.planning import BFSPlanner, GroundedTask
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
@@ -53,7 +54,13 @@ def test_subtypes_of_leaf_and_unknown():
 # -- supertype parameters bind subtype objects (the core fix) -----------------
 
 def test_supertype_param_binds_subtype_objects():
-    dp = _dp("logistics")
+    # Ground with the cartesian binder so the count is independent of the
+    # default static pruning (#12): this asserts #22 type-completeness.
+    dp = DomainProblem(
+        os.path.join(CORPUS, "logistics-domain.pddl"),
+        os.path.join(CORPUS, "logistics-problem.pddl"),
+        binder=CartesianBinder(),
+    )
     grounds = list(dp.ground_operator("drive-truck"))
     # ?loc-from / ?loc-to are typed `location`; objects are airports + locations.
     locs = {op.variable_list["?loc-from"] for op in grounds}


### PR DESCRIPTION
## Summary
Fixes #12. Operator grounding was a blind cartesian product over each parameter's type-compatible objects — it doesn't scale and offered no way to customize it. This PR factors binding behind a pluggable `VariableBinder` strategy and ships a smarter default.

- **`VariableBinder` ABC** (`pddlpy/binding.py`): `bind(dp, operator)` yields `{param: object}` maps.
- **`StaticPrunedBinder` (default)**: joins the operator's *static* positive preconditions against the initial state (each variable also type-checked) and filters static negatives, so only potentially-applicable bindings are generated. **Sound** — a static predicate (one no action ever modifies) has a fixed truth value across the whole search, so every dropped binding is genuinely never applicable. Disjunctive (`or`) preconditions fall back to the full product.
- **`CartesianBinder`**: the original full product over (now subtype-aware, from #22) candidates.
- **`DomainProblem`** gains a `binder` constructor arg / settable attribute, plus `candidate_objects()` and `static_predicates()`; declared predicate names are captured. Grounding is now stateless per call, retiring the per-operator `vargroundspace` cache (keeps #26 fixed by construction). Durative actions use the cartesian binder.

## Result
logistics `drive-truck` grounds to **16** same-city bindings instead of 64; BFS solves blocksworld / gripper / logistics identically under both binders (pruned bindings are a sound subset).

## Override
```python
dp = DomainProblem('d.pddl', 'p.pddl', binder=CartesianBinder())
dp.binder = MyBinder()   # custom VariableBinder
```

## Tests
New `tests/test_binding.py` (pruned⊂cartesian, dropped-bindings-are-inapplicable, pruned/cartesian solve identically, `static_predicates`, custom-binder plug-in, and the disjunctive / unsatisfiable / negative-static / type-mismatch / constant-in-precondition branches). Full suite green (127 passed); `pddlpy/pddl.py` and `pddlpy/binding.py` at **100%** line coverage; ruff + mypy clean.

## Stacking
**PR 2 of 2**, stacked on #78 (#22). Base branch is `type-supersets-22`; it will retarget to `main` once #78 merges. The diff vs #78 is binding-only (the type-hierarchy commit is shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)