### PR TITLE
Road to 1.0: durative validation, example showcase, issue triage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ demo: test
 	@echo "Running demos..."
 	for i in 1 2 3 4 6; do $(PYTHON) demo.py $$i ; done
 
+# Run the example showcase (examples/)
+examples: pyparser pddlpy/pddl.py
+	@echo "Running examples..."
+	for f in examples/[0-9][0-9]_*.py ; do echo "=== $$f ===" ; $(PYTHON) $$f ; done
+
 # Test published package from TestPyPI using Docker
 testpublish:
 	@echo "Testing pddlpy installation from TestPyPI..."
@@ -114,6 +119,7 @@ help:
 	@echo "  build        - Build distribution packages"
 	@echo "  clean        - Remove build artifacts"
 	@echo "  demo         - Run demo scripts"
+	@echo "  examples     - Run the example showcase (examples/)"
 	@echo "  testpublish  - Test package installation from TestPyPI (Docker)"
 	@echo "  pypitest     - Publish to TestPyPI"
 	@echo "  pypipublish  - Publish to PyPI"

--- a/PRD.md
+++ b/PRD.md
@@ -1,222 +1,135 @@
-# PRD: Parser Hardening, Planner Interface & PDDL Feature Expansion
+# PRD: Road to pddlpy 1.0
 
-> **Status:** Refined draft
+> **Status:** Active — supersedes the earlier "foundation-first" draft, which was written
+> against a stale snapshot. The foundation is already done (see §1).
 > **Owner:** Hernán
-> **Project:** `pddlpy` (Python PDDL parser + object model)
+> **Temporary file:** describes *what to do* for the 1.0 release. Retire after 1.0 ships.
+> Current capabilities always live in `README.md`; live status lives in `TODO.md`.
 
 ---
 
-## 1. Context
+## 1. Where we actually are (verified on `main`)
 
-The library provides a PDDL pipeline:
+The library is far more complete than a "parser only" tool. Verified present and tested:
 
-```
-ANTLR4 grammar → parse tree → listener → domain/problem object model
-```
+- **Parser + object model:** STRIPS, typing **with multi-level hierarchy** (`types()`,
+  `subtypes_of()`), pluggable variable binding (`StaticPrunedBinder`/`CartesianBinder`),
+  `:requirements` capture, case-insensitive keywords (standard IPC files parse).
+- **Precondition connectives** (and/or/not) handled — not silently flattened.
+- **Numeric fluents** (`:functions`, numeric preconditions/effects).
+- **Action costs** (`total-cost`, `:metric`), cost-optimal `ucs`.
+- **Planning layer** (`pddlpy.planning`, strictly layered): `State`, `Plan`, `GroundedTask`,
+  `Planner` ABC + `registry`, capability negotiation (`UnsupportedRequirementsError`), and
+  four reference planners — `bfs`, `astar`, `gbfs`, `ucs`.
+- **Durative actions:** parsed and **grounded** into a `DurativeAction` type with time-tagged
+  conditions (`at start`/`over all`/`at end`) and effects, plus duration. Even the previously
+  failing issue-#27 file now parses, grounds, and exposes its tags.
+- **Quality:** 127 tests, **100% line coverage** (804 statements, 0 missed), layering enforced
+  by `test_layering.py`.
 
-It parses STRIPS + typing into a `DomainProblem` / `Operator` / `Atom` model. It does
-**not** yet solve anything — the object model is the ceiling — and, despite the prior
-draft's claim, it does **not** reliably validate: standard IPC benchmarks fail to parse
-and several constructs are silently mis-handled (see §2). There is **1** unit test.
+**Implication:** the prior PRD's Phases 0–3 are shipped. 1.0 is a short, polish-and-release
+effort, not a feature build-out.
 
-This PRD covers three tracks, in dependency order:
+## 2. Goal
 
-0. **Harden the foundation** — fix the parser/model correctness bugs that block real use,
-   and build a test+coverage safety net so the layers above can be trusted.
-1. **Introduce a planner/solver layer** with a stable, pluggable interface.
-2. **Expand the supported PDDL subset** beyond STRIPS (numeric fluents, action costs,
-   durative actions), the object model evolving to support each.
+Ship a credible, stable **1.0.0** to PyPI **soon**. "1.0" is a promise of a stable public API
+and reliable behaviour for the subset we claim — it is **not** a promise of every PDDL feature.
 
-The guiding constraint remains a **strict layered architecture** — each layer depends only
-on the one below it, no leakage upward.
+## 3. Version horizon (agreed)
 
-```
-┌─────────────────────────────────────┐
-│  Planner interface (solve)           │  ← new   (Phase 1)
-├─────────────────────────────────────┤
-│  Domain / Problem object model       │  ← fix + extend  (Phase 0, then 2–4)
-├─────────────────────────────────────┤
-│  ANTLR4 grammar + parser/listener    │  ← fix + extend  (Phase 0, then 2–4)
-└─────────────────────────────────────┘
-```
+| Version | Theme | Tickets |
+|---------|-------|---------|
+| **1.0** | Finalize durative (validation/applicability), examples, docs, release | #23, #80, #81 |
+| **2.0** | **ADL** — conditional effects (`when`), quantifiers (`forall`/`exists`), full and/or/not tree | #10 |
+| **3.0 / future** | **HDDL** (HTN formalism) | #35 |
+| Future | Temporal planner that *solves* durative-action domains | — |
 
----
-
-## 2. Foundation problems (why Phase 0 exists)
-
-The previous PRD assumed a "working, validating pipeline" and went straight to a planner.
-Verification shows the foundation is not yet planner-ready. A planner stands precisely on
-correct grounding, correct preconditions, and comparable states — the things currently
-broken:
-
-| # | Symptom | Impact on a planner |
-|---|---------|---------------------|
-| #36 / #20 | Keywords are case-sensitive; `(:INIT ...)` in standard IPC files isn't recognized. `initialstate()` comes back **empty, no error**. Reproduced on IPC blocksworld. | Phase 0-style "solve blocksworld/gripper" fails at the parse step. Silent. |
-| #13 | `or` preconditions are flattened into the same flat positive/negative sets as `and`. No way to tell them apart. | Planner explores wrong state space; no error raised. |
-| #26 | `vargroundspace` is cached across operators; grounding a second operator reuses the first's variable bindings. | Successor generation produces invalid actions. |
-| #21 | `precondition_pos` holds tuples while `initialstate()` holds `Atom`s; they can't be compared/`issubset`. | Cannot check applicability — the core planner inner loop. |
-| #19 | A comment on the final line (no trailing newline) breaks parsing. | Real files fail to load. |
-
-**Conclusion:** building the planner before fixing these means building on sand. Phase 0
-fixes the parsing and grounding bugs (#36/#20, #26, #19, #13) and locks them in with tests +
-coverage before any planner code is written. **#21 is resolved in Phase 1**, where it is
-inseparable from the `State` type the planner needs (§5.3).
+ADL (#10) and HDDL (#35) are **out of scope for 1.0**. A temporal planner is out of scope
+indefinitely (the reference planners are non-temporal by design).
 
 ---
 
-## 3. Goals
+## 4. 1.0 scope — what to do
 
-- **Parse the standard STRIPS PDDL corpus correctly** (IPC blocksworld, gripper, logistics),
-  with keyword case-insensitivity and the grounding/precondition bugs fixed.
-- Establish a **measured test-coverage baseline** and drive line coverage toward 100%, using
-  failing/xfail tests to *document* remaining bugs rather than hide them.
-- Define an **abstract solver interface** so multiple planners can be registered and swapped
-  without changing the parser or object model.
-- Ship at least one **working reference planner** against STRIPS to prove the interface.
-- Keep layer boundaries strict and enforced (no planner reaching into parse trees; object
-  model imports no planner code).
-- Establish an extension path for numeric fluents, action costs, and durative actions that
-  does not require redesigning the interface each time.
+### 4.1 Durative actions — complete the "middle" slice (#23)
 
-## 4. Non-Goals
+Parsing, the `DurativeAction` object model, and grounding are **done**. For 1.0, add the
+**semantic / applicability** layer — **no temporal scheduler, no temporal planner**:
 
-- Competing with Fast Downward / LAMA on performance. The reference planner proves the
-  contract, it is not a benchmark entrant.
-- Full PDDL 3.x (preferences, constraints, trajectory constraints) this round.
-- HDDL (#35) — explicitly out of scope; record the decision and close.
-- A CLI / service / MCP wrapper. Out of scope until the library API stabilizes.
+- **Validation:** duration is well-formed and positive; time-tagged conditions/effects are
+  consistent and reference declared predicates/parameters; raise a clear error otherwise.
+- **Applicability:** given a state, check whether a grounded `DurativeAction`'s **`at start`**
+  conditions hold — analogous to `State.applicable(operator)` for instantaneous actions, but
+  **without** building a timeline or scheduling overlapping actions. For 1.0 we check **only
+  `at start`**; `over all` / `at end` applicability is documented as not yet evaluated.
+- **Surface:** a small dedicated **`DurativeState`** type in `pddlpy.planning`, mirroring the
+  existing `State.applicable` / `State.apply` ergonomics, kept layering-clean (imports the
+  object model, never the grammar).
+- Remove the now-stale `xfail`/"incomplete, Phase 4" markers in `tests/test_triage.py` /
+  `tests/test_durative.py`; add tests for the new validation/applicability.
+- **Explicitly keep documenting** that durative *solving* (temporal planning) is out of scope.
 
----
+### 4.2 More examples + README chapter (#80)
 
-## 5. Planner Interface Design (Phase 1)
+Add worked examples of increasing complexity for the capabilities users may not realise exist,
+and a README chapter with a table linking each:
 
-### 5.1 Baseline contract
+- Types / type hierarchies
+- Planners (bfs/astar/gbfs/ucs, registry)
+- Logical operators (and/or/not preconditions)
+- Numeric fluents and action costs
+- Durative actions (model + the new applicability check; note: not solved)
 
-```python
-class Planner(ABC):
-    @abstractmethod
-    def solve(self, domain: Domain, problem: Problem) -> Plan | None:
-        ...
-```
+> `#80` also lists "running as a tool" and an "LLM interface." There is no CLI/tool or LLM
+> surface today, and a thin CLI is **deferred to post-1.0** (decision §6), so those two
+> examples are **deferred** as well. Keep 1.0 examples to capabilities that already exist.
 
-- Returns a `Plan` (ordered actions, optionally timestamps/costs) or `None` if no plan exists.
-- `Domain` / `Problem` are the **already-fixed, validated** Phase 0 objects.
+### 4.3 Release engineering (#81)
 
-### 5.2 Interface granularity — decision
+- Bump `pyproject.toml` to `1.0.0`; set the `Development Status` classifier to
+  `5 - Production/Stable` (one-line change).
+- QA pass: `make` green, coverage still 100%, build wheel/sdist, smoke-test the wheel.
+- Publish to TestPyPI (`make pypitest`), verify install, then PyPI (`make pypipublish`).
+- Tag the release; short changelog of everything shipped since 0.4.x.
 
-Keep `solve(domain, problem) -> Plan` as the *public* contract, but internally factor out
-**grounding** and **successor generation** (`apply(state, action) -> state`) as shared,
-reusable components below the planner. A blind-search planner uses only the successor
-function; a future heuristic planner (FF/LAMA-style) reuses the same grounded representation
-without re-deriving it. This is feasible only once #26 (grounding) and #21 (state/atom
-typing) are fixed in Phase 0.
+### 4.4 Issue triage for a clean 1.0
 
-### 5.3 State representation
+- **Close as fixed (with the covering test):** #36 (case-insensitive parse), #16 (py2 import
+  gone), #19/#21/#26 (verify against current code, then close), #27 (dup of #23, now parses).
+- **Label out of scope / milestone:** #10 → 2.0, #35 → 3.0/future.
+- Confirm none of the above silently regressed before closing.
 
-Introduce an immutable, hashable `State` so search can build closed/open sets. This is also
-the clean resolution to #21 — `Operator.applicable(state)` and `state.apply(operator)` instead
-of ad-hoc tuple/`Atom` comparison.
+### 4.5 Docs
 
-### 5.4 Registration
-
-```python
-registry.register("bfs", BFSPlanner)
-registry.register("astar", AStarPlanner)
-planner = registry.get("astar")
-plan = planner.solve(domain, problem)
-```
-
-Capability metadata (costs? durations?) lets the caller pick a compatible planner — see §7.
+- Keep `README.md` describing **current** capabilities only (it already does); update it as
+  4.1/4.2 land — never ahead of the code.
+- `docs/object-model.md` updated for the durative applicability surface.
 
 ---
 
-## 6. Object Model Evolution
+## 5. Out of scope for 1.0
 
-| Feature            | Object model impact |
-|--------------------|---------------------|
-| STRIPS (current)   | `Operator` with add/delete sets, positive/negative preconditions |
-| OR / ADL (partial) | Precondition tree (and/or/not) instead of flat sets — needed to fix #13 honestly |
-| Numeric fluents    | Effects become expressions, not add/delete; `:functions`; numeric preconditions (#11) |
-| Action costs       | Special case of numeric fluents (`total-cost`); plan carries a cost |
-| Durative actions   | Distinct `DurativeAction` type; conditions/effects tagged `at start / over all / at end` (#23) |
+- ADL conditional effects / quantifiers (#10 → 2.0).
+- HDDL (#35 → 3.0/future).
+- Temporal planning / scheduling for durative actions (future).
+- Performance work / competing with Fast Downward / LAMA.
 
-**Design notes:** durative actions are *not* an extension of `Operator` — model them as a
-distinct type (state-transition model becomes temporal). Numeric fluents are the lower-risk
-intermediate step, land them before durations. Fixing #13 (OR) properly forces a precondition
-**tree** rather than flat sets; do this in Phase 0/early so the planner is built against the
-real shape, not refactored later.
+## 6. Resolved decisions
 
----
+- **Durative applicability surface:** a small dedicated **`DurativeState`** type in
+  `pddlpy.planning`.
+- **`over all` / `at end`:** for 1.0, check **`at start` only**; document the rest as not yet
+  evaluated.
+- **Thin CLI in 1.0:** **deferred** to post-1.0 → the #80 "running as a tool" / "LLM interface"
+  examples are deferred with it.
+- **Stability classifier:** **`5 - Production/Stable`**.
 
-## 7. Capability Negotiation
+(No open questions remain for 1.0.)
 
-Domains and planners declare capabilities, validated against PDDL `:requirements` (#9):
+## 7. Acceptance criteria (1.0)
 
-- The object model already knows what features a domain uses.
-- Each planner declares what it supports.
-- `solve()` / the registry **fails fast** with a clear error when a planner is handed a domain
-  beyond its subset (e.g. a STRIPS-only planner given durative actions).
-
----
-
-## 8. Phased Roadmap
-
-**Phase 0 — Foundation: correctness + coverage** *(new, gating)*
-- Fix keyword case-insensitivity (#20) → unblocks IPC parsing (#36).
-- Fix last-line comment handling (#19).
-- Fix grounding cross-operator cache bug (#26).
-- Preserve the OR/AND/NOT precondition connective (#13) — at minimum stop silently flattening
-  to AND. (Full ADL/DNF deferred to keep the phase short — see §6, #10.)
-- Stand up coverage tooling; add a benchmark parse-corpus; drive coverage toward 100% with
-  xfail markers documenting any bug not yet fixed.
-- Fix the broken `make testgrammar` Java classpath so grammar changes stay verifiable.
-
-**Phase 1 — Interface + reference planner (STRIPS)**
-- Define `Planner` ABC and `Plan` / `State` types.
-- Resolve state/atom type mismatch (#21) via the `State` type — comparable `State`/`Atom`
-  semantics so `operator.applicable(state)` works without manual casting.
-- Factor out grounding + successor generation as shared components.
-- Implement a blind-search reference planner (BFS, then A* / GBFS).
-- Capability metadata + registry.
-
-**Phase 2 — Numeric fluents** (#11)
-- Parse `:functions`, numeric preconditions, numeric effects.
-- Object model: effect expressions. Extend successor generation to evaluate them.
-
-**Phase 3 — Action costs**
-- `total-cost` handling; `Plan` carries cost. Cost-aware search.
-
-**Phase 4 — Durative actions** (#23)
-- `DurativeAction` type; time-tagged conditions/effects. Temporal state representation.
-- Temporal-capable planner, or document that the reference planner does not cover this.
-
----
-
-## 9. Open Questions
-
-- **Grounded vs lifted at the boundary:** does `solve` receive lifted actions and ground
-  internally, or is grounding a separate pre-pass the caller can invoke?
-- **OR depth in Phase 0:** full precondition tree + DNF evaluation now, or just preserve the
-  connective and defer full ADL (#10) to a later phase?
-- **Plan validation:** integrate a VAL-style validator to check produced plans? (We validate
-  domain/problem; validating *plans* closes the loop.)
-- **External planners:** does the same interface eventually wrap Fast Downward / LAMA via
-  subprocess, or a separate adapter layer? Affects how `Plan` and errors are modeled.
-- **API docs (#2):** generate docs in this round, or defer until the API stabilizes post-Phase 1?
-
-## 10. Acceptance Criteria
-
-**Phase 0**
-- IPC blocksworld and gripper domain+problem pairs parse correctly; `initialstate()` and
-  `goals()` are non-empty and match the files. (#36 regression test.)
-- Grounding two different operators yields correct, independent variable bindings. (#26.)
-- Coverage is measured and reported; line coverage at/near 100%, with every still-failing/xfail
-  test traceable to a documented bug.
-
-**Phase 1**
-- A `Planner` ABC exists with `solve(domain, problem) -> Plan | None`.
-- An operator's preconditions can be checked against a `State` without manual casting. (#21.)
-- At least one planner solves canonical STRIPS problems (blocksworld, gripper) correctly.
-- No planner module imports from the parser/grammar layer; the object model imports no planner
-  code (enforced by an import-linter rule or test).
-- A second planner registers and runs on the same problem without changing the layers below.
+- Durative actions: grounded actions can be validated and checked for `at start` applicability
+  via `DurativeState`; new tests pass; no stale `xfail` markers remain.
+- README has an examples chapter/table; each linked example runs.
+- `1.0.0` is installable from PyPI; `make` green; coverage 100%.
+- #36/#16/#19/#21/#26/#27 closed; #10 and #35 labelled to their milestones.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ In this repostory you'll find some PDDL examples files useful for testing purpos
 For instance, [domain-03.pddl](examples-pddl/domain-03.pddl)
 and [problem-03.pddl](examples-pddl/problem-03.pddl)
 
+#### Example showcase
+
+The [`examples/`](examples/) directory holds a set of self-contained, runnable
+scripts of increasing complexity, each demonstrating one capability against a
+bundled PDDL domain in [`examples/pddl/`](examples/pddl/). Run them all with
+`make examples`, or one at a time, e.g. `uv run python examples/01_parsing_basics.py`.
+
+| # | Example | What it shows | Capability |
+|---|---------|---------------|------------|
+| 01 | [01_parsing_basics.py](examples/01_parsing_basics.py) | Parse a typed domain/problem; read objects, init, goals, operators and grounded operators | Core object model |
+| 02 | [02_type_hierarchy.py](examples/02_type_hierarchy.py) | Multi-level `:types`, `types()` / `subtypes_of()`, supertype binding in grounding | Type hierarchies (#22) |
+| 03 | [03_logical_operators.py](examples/03_logical_operators.py) | Top-level `and` / `or` connective and negative preconditions in the model | Logical operators (#13) |
+| 04 | [04_planners.py](examples/04_planners.py) | The planner registry and BFS / A\* reference planners solving blocksworld and gripper | Planners (#1) |
+| 05 | [05_numeric_and_costs.py](examples/05_numeric_and_costs.py) | Numeric fluents (fuel-aware planning) and action costs (UCS cost-optimality) | Numeric fluents (#11) + action costs (#3) |
+| 06 | [06_durative.py](examples/06_durative.py) | Durative model, `DurativeState` `at start` applicability and validation — **not** temporally solved | Durative actions (#23) |
+
 ### Using the PDDL Python library ###
 
 To use this library the recommended way is to install it via PIP:

--- a/TODO.md
+++ b/TODO.md
@@ -44,8 +44,10 @@ left for 1.0 is durative finalization, examples, triage, and the PyPI release.
 - [ ] Tag release + short changelog since 0.4.x
 
 ### Issue triage (clean slate for 1.0)
-- [ ] Verify against current code, then **close**: #36, #16, #19, #21, #26, #27 (dup of #23)
-- [ ] Label **out of scope / milestone**: #10 → 2.0, #35 → 3.0/future
+- [x] Verify against current code, then **close**: #36, #16, #19, #21, #26, #27 (dup of #23).
+      *All verified fixed on `main` and now closed.*
+- [x] Scope to **milestone**: #10 → 2.0, #35 → 3.0. *Milestones 2.0 (#5) / 3.0 (#6) created;
+      #10 and #35 assigned with explanatory comments.*
 
 ### Docs
 - [ ] Update `README.md` as durative applicability + examples land (current capabilities only)

--- a/TODO.md
+++ b/TODO.md
@@ -10,16 +10,20 @@ left for 1.0 is durative finalization, examples, triage, and the PyPI release.
 ## 1.0 — must ship
 
 ### #23 — Durative actions: validation + applicability (the "middle" slice)
-- [ ] **Validation** — duration well-formed & positive; time-tagged conditions/effects
+- [x] **Validation** — duration well-formed & positive; time-tagged conditions/effects
       reference declared predicates/parameters; clear error otherwise.
-- [ ] **Applicability** — check a grounded `DurativeAction`'s **`at start`** conditions against
+      *`validate_durative_action` / `validate_durative_actions` + `DurativeValidationError`;
+      `DomainProblem.predicates()` accessor added.*
+- [x] **Applicability** — check a grounded `DurativeAction`'s **`at start`** conditions against
       a state, mirroring `State.applicable(operator)`. `over all`/`at end` not evaluated in 1.0.
-      **No scheduler, no temporal planner.**
-- [ ] **Surface:** small dedicated **`DurativeState`** type in `pddlpy.planning`; keep layering
-      clean (imports object model, never the grammar).
-- [ ] **Tests** — add validation/applicability tests; **remove stale `xfail`/"Phase 4" markers**
-      in `tests/test_triage.py` and `tests/test_durative.py`.
+      **No scheduler, no temporal planner.** *`DurativeState.applicable`.*
+- [x] **Surface:** small dedicated **`DurativeState`** type in `pddlpy.planning`; keep layering
+      clean (imports object model, never the grammar). *`pddlpy/planning/durative.py`.*
+- [x] **Tests** — add validation/applicability tests; **remove stale `xfail`/"Phase 4" markers**.
+      *`tests/test_durative_state.py` (16 tests, 100% cover of `durative.py`); cleaned the stale
+      triage docstring. No `@xfail` markers remained.*
 - [ ] Keep documenting that durative *solving* (temporal planning) is out of scope.
+      *(README update — pending, lands with #80.)*
 
 ### #80 — More examples + README chapter
 - [ ] Example: types / type hierarchies

--- a/TODO.md
+++ b/TODO.md
@@ -22,16 +22,19 @@ left for 1.0 is durative finalization, examples, triage, and the PyPI release.
 - [x] **Tests** — add validation/applicability tests; **remove stale `xfail`/"Phase 4" markers**.
       *`tests/test_durative_state.py` (16 tests, 100% cover of `durative.py`); cleaned the stale
       triage docstring. No `@xfail` markers remained.*
-- [ ] Keep documenting that durative *solving* (temporal planning) is out of scope.
-      *(README update — pending, lands with #80.)*
+- [x] Keep documenting that durative *solving* (temporal planning) is out of scope.
+      *README durative section + example showcase table both state "not temporally solved".*
 
 ### #80 — More examples + README chapter
-- [ ] Example: types / type hierarchies
-- [ ] Example: planners (bfs/astar/gbfs/ucs + registry)
-- [ ] Example: logical operators (and/or/not preconditions)
-- [ ] Example: numeric fluents + action costs
-- [ ] Example: durative actions (model + applicability; note: not solved)
-- [ ] README chapter with a table linking each example, increasing complexity
+- [x] Example: parsing basics (core object model) — *`examples/01_parsing_basics.py`*
+- [x] Example: types / type hierarchies — *`examples/02_type_hierarchy.py`*
+- [x] Example: logical operators (and/or/not preconditions) — *`examples/03_logical_operators.py`*
+- [x] Example: planners (bfs/astar + registry) — *`examples/04_planners.py`*
+- [x] Example: numeric fluents + action costs — *`examples/05_numeric_and_costs.py`*
+- [x] Example: durative actions (model + applicability; not solved) — *`examples/06_durative.py`*
+- [x] README chapter with a table linking each example, increasing complexity
+- [x] Self-contained PDDL under `examples/pddl/`; `make examples` target; smoke test
+      (`tests/test_examples.py`) runs every example. *Suite 150 passing, 100% coverage.*
 - [ ] ("running as a tool" / "LLM interface" examples — **deferred** post-1.0 with the thin CLI)
 
 ### #81 — Release v1.0 to PyPI

--- a/TODO.md
+++ b/TODO.md
@@ -1,133 +1,74 @@
-# TODO
+# TODO — Road to 1.0
 
-Ordered to match the PRD roadmap: **Phase 0 (foundation) gates everything else.** Issue
-numbers link to GitHub. Do not start a later phase until the prior phase's tests are green
-(or its failures are documented as xfail).
+Live status for the 1.0 release (see `PRD.md` for the detailed spec). Temporary file.
 
----
-
-## Phase 0 — Foundation: correctness + coverage  *(gating)*
-
-### Test & verification infrastructure (do first — it's the safety net for the fixes below)
-- [x] **Stand up coverage tooling** — add `pytest` + `coverage`/`pytest-cov`, wire into the
-      Makefile (`make coverage`), establish and print the baseline % for `pddlpy/pddl.py`.
-      *Baseline: 83% for `pddlpy/pddl.py`.*
-- [x] **Add a benchmark parse-corpus** — vendored canonical PDDL files (IPC blocksworld,
-      gripper, logistics) that MUST parse; the #36 regression guard.
-      *`tests/corpus/` + `tests/test_corpus.py` (9 tests).*
-- [x] **Fix `make testgrammar` Java classpath** — currently fails; Java can't find the ANTLR4
-      runtime. Add `antlr-4.13.2-complete.jar` to the classpath so grammar changes stay verifiable.
-      *Used absolute jar path (`$(CURDIR)`) so it survives `cd tmp`; added `.` to GRUN classpath.*
-- [x] **Drive line coverage toward 100%** — write tests covering every line of `pddl.py`.
-      Coverage is used here as a **bug-finder**: where a line can't be made to pass, mark the
-      test `xfail` with the owning issue number. Failing tests are EXPECTED and document
-      known/undiscovered bugs — do not delete or weaken them to go green.
-      *`pddlpy/pddl.py` at **100%** (23 passed, 1 xfail for #27/#23). The `__main__` guard is
-      `# pragma: no cover`; the legacy `pddlpy/test.py` scaffolding is omitted from coverage.*
-
-### Parser & object-model bug fixes (each lands with a regression test)
-- [x] **#20 / #36 — keyword case-insensitivity** — `(:INIT ...)` and other uppercase keywords
-      in standard IPC files are not recognized; `initialstate()` returns empty with no error.
-      Make grammar keywords case-insensitive. *Confirmed reproducible on IPC blocksworld.*
-      **Highest impact: unblocks parsing of real-world files.**
-      *Fixed via grammar `options { caseInsensitive = true; }`; identifiers keep their case.
-      Regression test `test_uppercase_keywords_parse`.*
-- [x] **#26 — grounding cross-operator cache bug** — `vargroundspace` cached per first operator;
-      grounding a second operator reuses the first's bindings. Key the cache correctly per
-      operator's own variable types. *Already keyed per operator name (`vargroundspace[opname]`);
-      verified independent + order-independent grounding and locked in with `tests/test_grounding.py`.*
-- [x] **#13 — OR preconditions silently flattened to AND** — at minimum **preserve the
-      connective** so `or` is distinguishable from `and` and no longer silently mis-modeled.
-      Full and/or/not tree + DNF evaluation is deferred to keep the phase short (see #10).
-      *Added `Operator.precondition_connective` ('and'|'or'), propagated to grounded operators;
-      tests in `tests/test_precondition_connective.py`.*
-- [x] **#19 — comment on last line breaks parsing** — adopt the suggested `LINE_COMMENT` rule
-      that accepts `EOF` as a terminator. *`('\r'? '\n' | EOF)`; regression test
-      `test_trailing_comment_without_newline`.*
-
-### Triage / investigation (Phase 0 scope)
-- [x] **#27 — user-supplied files fail to parse** — reproduce; likely a duplicate of #20/#23
-      (file uses `:durative-actions`). Confirm and link or fix. *Confirmed = #23: a
-      durative-action file raises `IndexError` in `enterTypedVariableList` (no
-      `enterDurativeActionDef` scope is pushed). Vendored fixture + `xfail` test
-      (`test_durative_action_parses`); fix deferred to Phase 4.*
-- [x] **#16 — `No module named '__builtin__'`** — Python 2 leftover; confirm it's gone on 3.11+
-      and close, or remove the offending import. *No `__builtin__`/py2 leftovers anywhere in the
-      repo; guarded by `test_no_python2_builtin_import`. Close.*
-- [x] **#18 — `InvalidCastException` reading types** (.NET port) — confirm scope; the .NET/DLL
-      path may be out of scope for this Python repo → decide & label. *No .NET/C#/DLL artifacts in
-      this repo; out of scope for the Python library. Label out-of-scope and close.*
+**Snapshot:** foundation + classical planner are done. 127 tests, **100% coverage**. What's
+left for 1.0 is durative finalization, examples, triage, and the PyPI release.
 
 ---
 
-## Phase 1 — Planner interface + reference planner (STRIPS)  *(addresses #1)*
-- [x] **Define `Planner` ABC + `Plan` / `State` types** (PRD §5). *`pddlpy/planning/`:
-      `Planner` ABC (`solve(domainproblem) -> Plan | None`), `State`, `Plan`.*
-- [x] **#21 — type mismatch `initialstate()` vs `precondition_pos`** — `Atom` vs tuple makes
-      `issubset` always false. Resolve via the new `State` type so `operator.applicable(state)`
-      works without manual casting. Linchpin: same change is both the bug fix and the planner's
-      core data structure. *`State` normalizes Atom/tuple; `state.applicable(op)` / `state.apply(op)`.*
-- [x] **Factor out grounding + successor generation** as shared components below the planner.
-      *`GroundedTask` (grounds once; `successors(state)` + `is_goal(state)`).*
-- [x] **Implement a blind-search reference planner** — BFS first, then A* / GBFS.
-      *`BFSPlanner`, `AStarPlanner` (goal-count), `GBFSPlanner`; solve blocksworld + gripper.*
-- [x] **Capability metadata + registry** (PRD §7); fail fast on unsupported `:requirements`.
-      *`Planner.capabilities` + `check_capabilities`; `PlannerRegistry` (`register`/`get`).*
-- [x] **#9 — enforce `:requirements`** — validate domain feature use against declared requirements.
-      *Capture in model (`DomainProblem.requirements()`); `validate_requirements()` enforces
-      typing/negative/disjunctive use vs declarations.*
-- [x] **Boundary enforcement test** — planner imports nothing from grammar; model imports no
-      planner code (import-linter rule or test). *`tests/test_layering.py` (static AST import scan).*
-- [x] **#2 — API docs** — document the planner + model API (or defer per Open Question §9).
-      *Docstrings throughout + README "Planning API" section; full docs site deferred.*
+## 1.0 — must ship
 
-## Phase 2 — Numeric fluents  *(#11)*
-- [x] Parse `:functions`, numeric preconditions, numeric effects. *`DomainProblem.functions()` +
-      `initial_numeric()`; operators carry `precondition_num`/`effect_num`; numeric init captured.*
-- [x] Object model: effect expressions; extend successor generation to evaluate them.
-      *`Expr` tree (Num/Fluent/BinOp/Neg), `NumericConstraint`, `NumericEffect`; `State` carries a
-      fluent valuation; BFS/A*/GBFS solve the numeric-transport domain. 100% coverage.*
+### #23 — Durative actions: validation + applicability (the "middle" slice)
+- [ ] **Validation** — duration well-formed & positive; time-tagged conditions/effects
+      reference declared predicates/parameters; clear error otherwise.
+- [ ] **Applicability** — check a grounded `DurativeAction`'s **`at start`** conditions against
+      a state, mirroring `State.applicable(operator)`. `over all`/`at end` not evaluated in 1.0.
+      **No scheduler, no temporal planner.**
+- [ ] **Surface:** small dedicated **`DurativeState`** type in `pddlpy.planning`; keep layering
+      clean (imports object model, never the grammar).
+- [ ] **Tests** — add validation/applicability tests; **remove stale `xfail`/"Phase 4" markers**
+      in `tests/test_triage.py` and `tests/test_durative.py`.
+- [ ] Keep documenting that durative *solving* (temporal planning) is out of scope.
 
-## Phase 3 — Action costs
-- [x] `total-cost` handling; `Plan` carries cost. *`:action-costs`/`:numeric-fluents` added to the
-      grammar; `(:metric ...)` captured (`DomainProblem.metric()`); `Plan.cost` = accumulated
-      `total-cost` (`costs.action_cost`/`plan_cost`, `TOTAL_COST`).*
-- [x] Cost-aware search in the reference planner. *`UniformCostPlanner` ("ucs") is cost-optimal;
-      on the travel domain UCS picks the cheaper 2-hop route (cost 2) vs BFS's 1-hop (cost 5).
-      100% coverage.*
+### #80 — More examples + README chapter
+- [ ] Example: types / type hierarchies
+- [ ] Example: planners (bfs/astar/gbfs/ucs + registry)
+- [ ] Example: logical operators (and/or/not preconditions)
+- [ ] Example: numeric fluents + action costs
+- [ ] Example: durative actions (model + applicability; note: not solved)
+- [ ] README chapter with a table linking each example, increasing complexity
+- [ ] ("running as a tool" / "LLM interface" examples — **deferred** post-1.0 with the thin CLI)
 
-## Phase 4 — Durative actions  *(#23)*
-- [x] **Complete duration-tag recovery** — grammar parses durative actions but Python recovery
-      is incomplete (the known issue in CLAUDE.md). *Fixed: durative actions no longer crash the
-      listener; duration recovered (`DurativeAction.duration`). Resolves #23/#27.*
-- [x] **`DurativeAction` type** — time-tagged conditions/effects (`at start / over all / at end`).
-      *`DurativeAction` with `condition_pos/neg` (start/over/end) and `effect_pos/neg` (start/end);
-      `DomainProblem.durative_operators()` + `ground_durative_operator()`. 100% coverage.*
-- [x] Decide temporal state representation; temporal-capable planner (or document non-coverage).
-      *Documented non-coverage: the reference planners are non-temporal and do not solve durative
-      domains (PRD §4/§8). The object model fully recovers durative actions.*
+### #81 — Release v1.0 to PyPI
+- [ ] Bump `pyproject.toml` → `1.0.0`; set `Development Status` classifier to `5 - Production/Stable`
+- [ ] QA: `make` green, coverage 100%, build wheel/sdist, smoke-test the wheel
+- [ ] Publish TestPyPI (`make pypitest`) → verify install → PyPI (`make pypipublish`)
+- [ ] Tag release + short changelog since 0.4.x
+
+### Issue triage (clean slate for 1.0)
+- [ ] Verify against current code, then **close**: #36, #16, #19, #21, #26, #27 (dup of #23)
+- [ ] Label **out of scope / milestone**: #10 → 2.0, #35 → 3.0/future
+
+### Docs
+- [ ] Update `README.md` as durative applicability + examples land (current capabilities only)
+- [ ] Update `docs/object-model.md` for the durative applicability surface
 
 ---
 
-## Backlog / decisions
-- [ ] **#10 — ADL** (conditional effects, quantifiers) — schedule after #13's precondition tree.
-- [x] **#12 — better variable binding** — revisit once grounding (#26) is fixed; may be subsumed.
-      *Factored grounding behind a pluggable `VariableBinder` (`pddlpy/binding.py`): default
-      `StaticPrunedBinder` joins static positive preconditions against the initial state (sound:
-      static predicates never change) and filters static negatives, yielding a subset of the
-      cartesian bindings — e.g. logistics `drive-truck` 16 vs 64. `CartesianBinder` keeps the
-      full product; users pass `binder=` or set `dp.binder`. Disjunctive preconditions fall back
-      to cartesian. Retires the per-operator `vargroundspace` cache. Builds on #22's subtype-aware
-      candidates.*
-- [x] **#22 — type super-sets** — typing hierarchy enhancement; Phase 2-ish. *Capture the
-      `:types` subtype→supertype map (`DomainProblem.types()`/`subtypes_of()`); subtype-aware
-      grounding (`_is_subtype`) so a supertype-typed param binds objects of any transitive
-      subtype. logistics now grounds + solves. `(either ...)` union types still unhandled.*
-- [ ] **#35 — HDDL parser** — decided **out of scope** (PRD §4). Reply and close.
+## 2.0 — ADL (#10) — out of scope for 1.0
+- [ ] Conditional effects (`when`)
+- [ ] Quantifiers (`forall` / `exists`) in conditions
+- [ ] Full and/or/not precondition tree (beyond the current connective handling)
 
-## Done / merged
-- [x] **Merge `ai-setup` branch** — CLAUDE.md setup (merged, #60).
+## 3.0 / future — HDDL (#35) — out of scope
+- [ ] HTN / HDDL parser — separate formalism; decide as a distinct effort
+
+## Future (no milestone)
+- [ ] Temporal planner that *solves* durative-action domains
+- [ ] Heuristic improvements for the reference planners
 
 ---
 
-*Last updated: 2026-06-14*
+## Done (recent, verified)
+- [x] Case-insensitive keywords → standard IPC files parse (#36)
+- [x] `:requirements` capture + capability negotiation (#9)
+- [x] Planner interface + registry + bfs/astar/gbfs/ucs
+- [x] Numeric fluents (#11), action costs (#3)
+- [x] Type hierarchy (#22), pluggable variable binding (#12)
+- [x] Durative parsing + `DurativeAction` model + grounding (#23 parsing half)
+- [x] Precondition connectives (#13), strict layering, **100% coverage**
+
+---
+
+*Last updated: 2026-06-21*

--- a/examples/01_parsing_basics.py
+++ b/examples/01_parsing_basics.py
@@ -1,0 +1,33 @@
+"""Example 01 — Parsing basics.
+
+Parse a typed STRIPS domain/problem (gripper) and read the core object model:
+objects, operators, initial state, goals, and the grounded instances of an
+operator. Start here.
+"""
+import os
+
+from pddlpy import DomainProblem
+
+PDDL = os.path.join(os.path.dirname(__file__), "pddl")
+
+
+def main():
+    dp = DomainProblem(
+        os.path.join(PDDL, "gripper-domain.pddl"),
+        os.path.join(PDDL, "gripper-problem.pddl"),
+    )
+
+    print("operators:", list(dp.operators()))
+    print("objects:  ", dp.worldobjects())
+    print("init:     ", dp.initialstate())
+    print("goals:    ", dp.goals())
+
+    print("\ngrounded 'pick' instances:")
+    for op in dp.ground_operator("pick"):
+        print("  vars:", op.variable_list)
+        print("    pre+:", op.precondition_pos, " pre-:", op.precondition_neg)
+        print("    eff+:", op.effect_pos, " eff-:", op.effect_neg)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_type_hierarchy.py
+++ b/examples/02_type_hierarchy.py
@@ -1,0 +1,35 @@
+"""Example 02 — Type hierarchies (#22).
+
+The logistics domain declares a multi-level `:types` hierarchy
+(``truck - vehicle``, ``vehicle - physobj``, ``airport - location`` ...). A
+parameter typed with a supertype binds objects of any transitive subtype, so
+grounding respects the hierarchy. Inspect it with ``types()`` /
+``subtypes_of()``.
+"""
+import os
+
+from pddlpy import DomainProblem
+
+PDDL = os.path.join(os.path.dirname(__file__), "pddl")
+
+
+def main():
+    dp = DomainProblem(
+        os.path.join(PDDL, "logistics-domain.pddl"),
+        os.path.join(PDDL, "logistics-problem.pddl"),
+    )
+
+    print("types (subtype -> direct supertype):")
+    for sub, sup in sorted(dp.types().items()):
+        print("  %-10s -> %s" % (sub, sup))
+
+    print("\nall transitive subtypes of 'object':", sorted(dp.subtypes_of("object")))
+    print("all transitive subtypes of 'vehicle':", sorted(dp.subtypes_of("vehicle")))
+
+    # 'load-truck' takes a ?loc typed 'location'; airports (a subtype) bind too.
+    n = sum(1 for _ in dp.ground_operator("load-truck"))
+    print("\ngrounded 'load-truck' instances (supertype binding in action):", n)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_logical_operators.py
+++ b/examples/03_logical_operators.py
@@ -1,0 +1,34 @@
+"""Example 03 — Logical operators (#13).
+
+The top-level precondition connective (``and`` vs ``or``) is recovered into the
+object model, and negative preconditions are kept separate from positive ones.
+Full and/or/not *tree evaluation* is deferred to ADL (#10) — here we just show
+what the model exposes.
+"""
+import os
+
+from pddlpy import DomainProblem
+
+PDDL = os.path.join(os.path.dirname(__file__), "pddl")
+
+
+def main():
+    dp = DomainProblem(
+        os.path.join(PDDL, "logic-domain.pddl"),
+        os.path.join(PDDL, "logic-problem.pddl"),
+    )
+
+    for name in dp.operators():
+        op = dp.domain.operators[name]
+        print("action %r" % name)
+        print("  connective: %s" % op.precondition_connective)
+        print("  pre+:", op.precondition_pos)
+        print("  pre-:", op.precondition_neg)
+
+    # 'open-door' is disjunctive; 'force-door' is a conjunction with a negation.
+    assert dp.domain.operators["open-door"].precondition_connective == "or"
+    assert dp.domain.operators["force-door"].precondition_neg
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_planners.py
+++ b/examples/04_planners.py
@@ -1,0 +1,39 @@
+"""Example 04 — Reference planners (#1).
+
+The optional ``pddlpy.planning`` layer ships blind-search reference planners
+behind a registry. Look one up by name and call ``solve(dp)``; you get a
+``Plan`` (ordered grounded actions + a cost) or ``None``.
+"""
+import os
+
+from pddlpy import DomainProblem
+from pddlpy.planning import get, registry
+
+PDDL = os.path.join(os.path.dirname(__file__), "pddl")
+
+
+def _dp(name):
+    return DomainProblem(
+        os.path.join(PDDL, "%s-domain.pddl" % name),
+        os.path.join(PDDL, "%s-problem.pddl" % name),
+    )
+
+
+def main():
+    print("registered planners:", registry.names())
+
+    bw = _dp("blocksworld")
+    plan = get("astar").solve(bw)
+    print("\nblocksworld via A* — %d actions, cost %s:" % (len(plan), plan.cost))
+    for op_name, binding in plan.action_names():
+        print("  %s %s" % (op_name, binding))
+
+    grip = _dp("gripper")
+    plan = get("bfs").solve(grip)
+    print("\ngripper via BFS — %d actions:" % len(plan))
+    for op_name, binding in plan.action_names():
+        print("  %s %s" % (op_name, binding))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_numeric_and_costs.py
+++ b/examples/05_numeric_and_costs.py
@@ -1,0 +1,41 @@
+"""Example 05 — Numeric fluents (#11) and action costs (#3).
+
+Numeric fluents: the transport domain guards ``drive`` with ``(>= (fuel ?v) ...)``
+and decreases fuel as an effect; the planner respects the numeric constraints.
+
+Action costs: the travel domain accrues ``total-cost``; ``ucs`` is cost-optimal
+and prefers a cheaper multi-hop route over a single expensive hop, whereas
+``bfs`` (which minimizes the *number* of actions) does not.
+"""
+import os
+
+from pddlpy import DomainProblem
+from pddlpy.planning import get
+
+PDDL = os.path.join(os.path.dirname(__file__), "pddl")
+
+
+def _dp(name):
+    return DomainProblem(
+        os.path.join(PDDL, "%s-domain.pddl" % name),
+        os.path.join(PDDL, "%s-problem.pddl" % name),
+    )
+
+
+def main():
+    nt = _dp("numeric-transport")
+    print("functions:", nt.functions())
+    print("initial numeric valuation:", nt.initial_numeric())
+    plan = get("bfs").solve(nt)
+    print("numeric-transport plan (fuel-aware):", plan.action_names())
+
+    travel = _dp("travel")
+    print("\nmetric:", travel.metric())
+    bfs_plan = get("bfs").solve(travel)
+    ucs_plan = get("ucs").solve(travel)
+    print("bfs : %d actions, cost %s" % (len(bfs_plan), bfs_plan.cost))
+    print("ucs : %d actions, cost %s  <- cost-optimal" % (len(ucs_plan), ucs_plan.cost))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_durative.py
+++ b/examples/06_durative.py
@@ -1,0 +1,40 @@
+"""Example 06 — Durative actions (#23).
+
+Durative actions are parsed and grounded into a ``DurativeAction`` (time-tagged
+``at start`` / ``over all`` / ``at end`` conditions and effects, plus a
+duration). ``DurativeState`` answers whether a grounded action can *start* in a
+state, and ``validate_durative_actions`` checks they are well-formed.
+
+NOT included: a temporal planner. Solving durative domains (scheduling, overlap,
+``over all`` / ``at end`` enforcement over a timeline) is out of scope — the
+reference planners are non-temporal.
+"""
+import os
+
+from pddlpy import DomainProblem
+from pddlpy.planning import DurativeState, validate_durative_actions
+
+PDDL = os.path.join(os.path.dirname(__file__), "pddl")
+
+
+def main():
+    dp = DomainProblem(
+        os.path.join(PDDL, "durative-action-domain.pddl"),
+        os.path.join(PDDL, "durative-action-problem.pddl"),
+    )
+
+    validate_durative_actions(dp)  # raises DurativeValidationError if malformed
+    print("durative actions:", list(dp.durative_operators()))
+
+    state = DurativeState.from_problem(dp)
+    print("initial state:", sorted(state))
+    print("\ngrounded 'go' instances — can each START now?")
+    for ga in dp.ground_durative_operator("go"):
+        print(
+            "  %s  duration=%s  at-start-applicable=%s"
+            % (ga.variable_list, ga.duration, state.applicable(ga))
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pddl/blocksworld-domain.pddl
+++ b/examples/pddl/blocksworld-domain.pddl
@@ -1,0 +1,43 @@
+;; Canonical 4-operator STRIPS blocksworld (IPC).
+(define (domain blocksworld)
+  (:requirements :strips)
+  (:predicates
+    (clear ?x)
+    (ontable ?x)
+    (handempty)
+    (holding ?x)
+    (on ?x ?y))
+
+  (:action pick-up
+    :parameters (?x)
+    :precondition (and (clear ?x) (ontable ?x) (handempty))
+    :effect (and (not (ontable ?x))
+                 (not (clear ?x))
+                 (not (handempty))
+                 (holding ?x)))
+
+  (:action put-down
+    :parameters (?x)
+    :precondition (holding ?x)
+    :effect (and (not (holding ?x))
+                 (clear ?x)
+                 (handempty)
+                 (ontable ?x)))
+
+  (:action stack
+    :parameters (?x ?y)
+    :precondition (and (holding ?x) (clear ?y))
+    :effect (and (not (holding ?x))
+                 (not (clear ?y))
+                 (clear ?x)
+                 (handempty)
+                 (on ?x ?y)))
+
+  (:action unstack
+    :parameters (?x ?y)
+    :precondition (and (on ?x ?y) (clear ?x) (handempty))
+    :effect (and (holding ?x)
+                 (clear ?y)
+                 (not (clear ?x))
+                 (not (handempty))
+                 (not (on ?x ?y)))))

--- a/examples/pddl/blocksworld-problem.pddl
+++ b/examples/pddl/blocksworld-problem.pddl
@@ -1,0 +1,8 @@
+(define (problem blocksworld-01)
+  (:domain blocksworld)
+  (:objects a b c)
+  (:init
+    (clear a) (clear b) (clear c)
+    (ontable a) (ontable b) (ontable c)
+    (handempty))
+  (:goal (and (on a b) (on b c))))

--- a/examples/pddl/durative-action-domain.pddl
+++ b/examples/pddl/durative-action-domain.pddl
@@ -1,0 +1,19 @@
+;; Durative-action domain (#23): a move with time-tagged conditions and
+;; effects ('at start' / 'over all' / 'at end').
+(define (domain da)
+  (:requirements :strips :typing :durative-actions)
+  (:types loc)
+  (:predicates
+    (at ?l - loc)
+    (visited ?l - loc)
+    (road ?a - loc ?b - loc))
+
+  (:durative-action go
+    :parameters (?from - loc ?to - loc)
+    :duration (= ?duration 5)
+    :condition (and (at start (at ?from))
+                    (over all (road ?from ?to))
+                    (at end (road ?from ?to)))
+    :effect (and (at start (not (at ?from)))
+                 (at end (at ?to))
+                 (at end (visited ?to)))))

--- a/examples/pddl/durative-action-problem.pddl
+++ b/examples/pddl/durative-action-problem.pddl
@@ -1,0 +1,5 @@
+(define (problem dap)
+  (:domain da)
+  (:objects a b - loc)
+  (:init (at a) (road a b))
+  (:goal (visited b)))

--- a/examples/pddl/gripper-domain.pddl
+++ b/examples/pddl/gripper-domain.pddl
@@ -1,0 +1,29 @@
+;; Canonical gripper domain (IPC), typed STRIPS.
+(define (domain gripper)
+  (:requirements :strips :typing)
+  (:types room ball gripper)
+  (:predicates
+    (at-robby ?r - room)
+    (at ?b - ball ?r - room)
+    (free ?g - gripper)
+    (carry ?o - ball ?g - gripper))
+
+  (:action move
+    :parameters (?from - room ?to - room)
+    :precondition (at-robby ?from)
+    :effect (and (at-robby ?to)
+                 (not (at-robby ?from))))
+
+  (:action pick
+    :parameters (?obj - ball ?room - room ?gripper - gripper)
+    :precondition (and (at ?obj ?room) (at-robby ?room) (free ?gripper))
+    :effect (and (carry ?obj ?gripper)
+                 (not (at ?obj ?room))
+                 (not (free ?gripper))))
+
+  (:action drop
+    :parameters (?obj - ball ?room - room ?gripper - gripper)
+    :precondition (and (carry ?obj ?gripper) (at-robby ?room))
+    :effect (and (at ?obj ?room)
+                 (free ?gripper)
+                 (not (carry ?obj ?gripper)))))

--- a/examples/pddl/gripper-problem.pddl
+++ b/examples/pddl/gripper-problem.pddl
@@ -1,0 +1,11 @@
+(define (problem gripper-01)
+  (:domain gripper)
+  (:objects
+    rooma roomb - room
+    ball1 ball2 - ball
+    left right - gripper)
+  (:init
+    (at-robby rooma)
+    (free left) (free right)
+    (at ball1 rooma) (at ball2 rooma))
+  (:goal (and (at ball1 roomb) (at ball2 roomb))))

--- a/examples/pddl/logic-domain.pddl
+++ b/examples/pddl/logic-domain.pddl
@@ -1,0 +1,24 @@
+;; Logical-operators demo. Two ways to open a door:
+;;  * open-door  -- a top-level DISJUNCTIVE precondition: the door opens if it is
+;;                  unlocked OR the actor holds a key (precondition_connective='or').
+;;  * force-door -- a conjunction with a NEGATIVE precondition: force it only if it
+;;                  is not already open and it is jammed (precondition_neg non-empty).
+;; Shows how the top-level connective and negative preconditions are recovered
+;; into the object model (#13).
+(define (domain logic)
+  (:requirements :strips :disjunctive-preconditions :negative-preconditions)
+  (:predicates
+    (unlocked ?d)
+    (has-key ?d)
+    (jammed ?d)
+    (open ?d))
+
+  (:action open-door
+    :parameters (?d)
+    :precondition (or (unlocked ?d) (has-key ?d))
+    :effect (open ?d))
+
+  (:action force-door
+    :parameters (?d)
+    :precondition (and (not (open ?d)) (jammed ?d))
+    :effect (open ?d)))

--- a/examples/pddl/logic-problem.pddl
+++ b/examples/pddl/logic-problem.pddl
@@ -1,0 +1,5 @@
+(define (problem logic-1)
+  (:domain logic)
+  (:objects front)
+  (:init (has-key front))
+  (:goal (open front)))

--- a/examples/pddl/logistics-domain.pddl
+++ b/examples/pddl/logistics-domain.pddl
@@ -1,0 +1,42 @@
+;; Canonical logistics domain (IPC), typed STRIPS with a type hierarchy.
+(define (domain logistics)
+  (:requirements :strips :typing)
+  (:types truck airplane - vehicle
+          package vehicle - physobj
+          airport - location
+          city location - object
+          physobj - object)
+  (:predicates
+    (in-city ?loc - location ?city - city)
+    (at ?obj - physobj ?loc - location)
+    (in ?pkg - package ?veh - vehicle))
+
+  (:action load-truck
+    :parameters (?pkg - package ?truck - truck ?loc - location)
+    :precondition (and (at ?truck ?loc) (at ?pkg ?loc))
+    :effect (and (not (at ?pkg ?loc)) (in ?pkg ?truck)))
+
+  (:action load-airplane
+    :parameters (?pkg - package ?airplane - airplane ?loc - location)
+    :precondition (and (at ?pkg ?loc) (at ?airplane ?loc))
+    :effect (and (not (at ?pkg ?loc)) (in ?pkg ?airplane)))
+
+  (:action unload-truck
+    :parameters (?pkg - package ?truck - truck ?loc - location)
+    :precondition (and (at ?truck ?loc) (in ?pkg ?truck))
+    :effect (and (not (in ?pkg ?truck)) (at ?pkg ?loc)))
+
+  (:action unload-airplane
+    :parameters (?pkg - package ?airplane - airplane ?loc - location)
+    :precondition (and (in ?pkg ?airplane) (at ?airplane ?loc))
+    :effect (and (not (in ?pkg ?airplane)) (at ?pkg ?loc)))
+
+  (:action drive-truck
+    :parameters (?truck - truck ?loc-from - location ?loc-to - location ?city - city)
+    :precondition (and (at ?truck ?loc-from) (in-city ?loc-from ?city) (in-city ?loc-to ?city))
+    :effect (and (not (at ?truck ?loc-from)) (at ?truck ?loc-to)))
+
+  (:action fly-airplane
+    :parameters (?airplane - airplane ?loc-from - airport ?loc-to - airport)
+    :precondition (at ?airplane ?loc-from)
+    :effect (and (not (at ?airplane ?loc-from)) (at ?airplane ?loc-to))))

--- a/examples/pddl/logistics-problem.pddl
+++ b/examples/pddl/logistics-problem.pddl
@@ -1,0 +1,16 @@
+(define (problem logistics-01)
+  (:domain logistics)
+  (:objects
+    apn1 - airplane
+    apt1 apt2 - airport
+    pos1 pos2 - location
+    cit1 cit2 - city
+    tru1 tru2 - truck
+    obj1 obj2 - package)
+  (:init
+    (in-city pos1 cit1) (in-city apt1 cit1)
+    (in-city pos2 cit2) (in-city apt2 cit2)
+    (at apn1 apt2)
+    (at tru1 pos1) (at obj1 pos1)
+    (at tru2 pos2) (at obj2 pos2))
+  (:goal (and (at obj1 apt1) (at obj2 pos1))))

--- a/examples/pddl/numeric-transport-domain.pddl
+++ b/examples/pddl/numeric-transport-domain.pddl
@@ -1,0 +1,21 @@
+;; Minimal numeric-fluents domain: a vehicle drives between locations,
+;; consuming fuel. Exercises :functions, a numeric precondition (>=) and a
+;; numeric effect (decrease).
+(define (domain numeric-transport)
+  (:requirements :strips :typing :fluents)
+  (:types location vehicle)
+  (:predicates
+    (at ?v - vehicle ?l - location)
+    (road ?from - location ?to - location))
+  (:functions
+    (fuel ?v - vehicle)
+    (fuel-cost ?from - location ?to - location))
+
+  (:action drive
+    :parameters (?v - vehicle ?from - location ?to - location)
+    :precondition (and (at ?v ?from)
+                       (road ?from ?to)
+                       (>= (fuel ?v) (fuel-cost ?from ?to)))
+    :effect (and (not (at ?v ?from))
+                 (at ?v ?to)
+                 (decrease (fuel ?v) (fuel-cost ?from ?to)))))

--- a/examples/pddl/numeric-transport-problem.pddl
+++ b/examples/pddl/numeric-transport-problem.pddl
@@ -1,0 +1,12 @@
+(define (problem numeric-transport-01)
+  (:domain numeric-transport)
+  (:objects
+    truck - vehicle
+    a b c - location)
+  (:init
+    (at truck a)
+    (road a b) (road b c)
+    (= (fuel truck) 100)
+    (= (fuel-cost a b) 30)
+    (= (fuel-cost b c) 40))
+  (:goal (at truck c)))

--- a/examples/pddl/travel-domain.pddl
+++ b/examples/pddl/travel-domain.pddl
@@ -1,0 +1,19 @@
+;; Action-costs domain: moving between connected places accrues total-cost
+;; equal to the distance travelled. A cost-aware planner should prefer the
+;; cheaper multi-hop route over a single expensive hop.
+(define (domain travel)
+  (:requirements :strips :typing :action-costs)
+  (:types place)
+  (:predicates
+    (at ?p - place)
+    (connected ?a - place ?b - place))
+  (:functions
+    (total-cost)
+    (distance ?a - place ?b - place))
+
+  (:action move
+    :parameters (?from - place ?to - place)
+    :precondition (and (at ?from) (connected ?from ?to))
+    :effect (and (not (at ?from))
+                 (at ?to)
+                 (increase (total-cost) (distance ?from ?to)))))

--- a/examples/pddl/travel-problem.pddl
+++ b/examples/pddl/travel-problem.pddl
@@ -1,0 +1,12 @@
+(define (problem travel-01)
+  (:domain travel)
+  (:objects a b c - place)
+  (:init
+    (at a)
+    (connected a b) (connected b c) (connected a c)
+    (= (total-cost) 0)
+    (= (distance a b) 1)
+    (= (distance b c) 1)
+    (= (distance a c) 5))
+  (:goal (at c))
+  (:metric minimize (total-cost)))

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -29,7 +29,7 @@ solver layer built on top of this model.
 from __future__ import annotations
 
 import operator as _operator
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, cast
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, cast
 
 from antlr4 import CommonTokenStream, FileStream, ParseTreeWalker
 
@@ -731,6 +731,12 @@ class DomainProblem():
         domain declares none.
         """
         return set(self.domain.requirements)
+
+    def predicates(self) -> Set[str]:
+        """Returns the set of predicate names declared in the domain's
+        :predicates section, e.g. {'at', 'road', 'visited'}.
+        """
+        return set(self.domain.predicates)
 
     def functions(self) -> Dict[str, List[Tuple[str, Optional[str]]]]:
         """Returns a dict mapping each declared :functions name to its ordered

--- a/pddlpy/planning/__init__.py
+++ b/pddlpy/planning/__init__.py
@@ -12,6 +12,12 @@ from .base import (
     validate_requirements,
 )
 from .costs import TOTAL_COST, action_cost, plan_cost
+from .durative import (
+    DurativeState,
+    DurativeValidationError,
+    validate_durative_action,
+    validate_durative_actions,
+)
 from .grounding import GroundedTask
 from .registry import get, register, registry
 from .search import (
@@ -27,6 +33,10 @@ __all__ = [
     "State",
     "Plan",
     "atom_tuple",
+    "DurativeState",
+    "DurativeValidationError",
+    "validate_durative_action",
+    "validate_durative_actions",
     "GroundedTask",
     "Planner",
     "PlannerError",

--- a/pddlpy/planning/durative.py
+++ b/pddlpy/planning/durative.py
@@ -1,0 +1,146 @@
+"""Durative-action validation and a small applicability state (#23).
+
+The object model already parses and grounds durative actions into
+``DurativeAction`` (time-tagged ``at start`` / ``over all`` / ``at end``
+conditions and effects, plus a duration). This module adds the *semantic*
+layer the reference planners deliberately stop short of:
+
+* :func:`validate_durative_action` — structural checks (well-formed positive
+  duration; conditions/effects reference declared predicates and the action's
+  own parameters).
+* :class:`DurativeState` — a small, dedicated state that answers a single
+  question: are a grounded durative action's **``at start``** conditions
+  satisfied? This is *not* a temporal planner — there is no timeline, no
+  scheduling of ``over all`` / ``at end`` conditions, and no overlap handling.
+  Solving durative domains remains out of scope (PRD §3/§5).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional, Set
+
+from .base import PlannerError
+from .state import GroundAtom, atom_tuple
+
+if TYPE_CHECKING:
+    from pddlpy.pddl import DomainProblem, DurativeAction
+
+
+class DurativeValidationError(PlannerError):
+    """Raised when a ``DurativeAction`` is structurally invalid."""
+
+
+def _all_atoms(action: "DurativeAction") -> Iterator[GroundAtom]:
+    """Yield every condition and effect atom of the action as a tuple."""
+    for time in action.CONDITION_TIMES:
+        for atom in action.condition_pos[time]:
+            yield atom_tuple(atom)
+        for atom in action.condition_neg[time]:
+            yield atom_tuple(atom)
+    for time in action.EFFECT_TIMES:
+        for atom in action.effect_pos[time]:
+            yield atom_tuple(atom)
+        for atom in action.effect_neg[time]:
+            yield atom_tuple(atom)
+
+
+def validate_durative_action(
+    action: "DurativeAction",
+    declared_predicates: Optional[Set[str]] = None,
+) -> None:
+    """Validate a durative action; raise :class:`DurativeValidationError` if
+    malformed.
+
+    Checks, in order:
+
+    1. ``duration`` is present and strictly positive.
+    2. Every variable (a ``?``-prefixed token) used in a condition/effect is a
+       declared parameter of the action (in ``variable_list``).
+    3. If ``declared_predicates`` is given, every predicate referenced by a
+       condition/effect is declared in the domain.
+
+    ``declared_predicates`` is optional so a single grounded action can be
+    validated standalone; pass ``DomainProblem.predicates()`` to enforce check 3.
+    """
+    name = action.operator_name
+    if action.duration is None:
+        raise DurativeValidationError(
+            "durative action %r has no simple numeric duration" % name
+        )
+    if action.duration <= 0:
+        raise DurativeValidationError(
+            "durative action %r has non-positive duration %r" % (name, action.duration)
+        )
+
+    params = set(action.variable_list)
+    for atom in _all_atoms(action):
+        for token in atom:
+            if token.startswith("?") and token not in params:
+                raise DurativeValidationError(
+                    "durative action %r references undeclared parameter %r"
+                    % (name, token)
+                )
+        if declared_predicates is not None and atom and atom[0] not in declared_predicates:
+            raise DurativeValidationError(
+                "durative action %r references undeclared predicate %r"
+                % (name, atom[0])
+            )
+
+
+def validate_durative_actions(domainproblem: "DomainProblem") -> None:
+    """Validate every durative action declared in ``domainproblem`` against its
+    declared predicates. No-op for domains without durative actions."""
+    predicates = domainproblem.predicates()
+    for action in domainproblem.domain.durative_operators.values():
+        validate_durative_action(action, predicates)
+
+
+class DurativeState:
+    """A small immutable state for checking durative ``at start`` applicability.
+
+    Holds a set of ground atoms (tuples). Unlike :class:`~pddlpy.planning.State`
+    it carries no numeric valuation and models no timeline: durative+numeric and
+    temporal scheduling are out of scope for 1.0.
+    """
+
+    __slots__ = ("_atoms",)
+
+    def __init__(self, atoms: Iterable[Any] = ()) -> None:
+        self._atoms: frozenset[GroundAtom] = frozenset(atom_tuple(a) for a in atoms)
+
+    @property
+    def atoms(self) -> frozenset[GroundAtom]:
+        return self._atoms
+
+    @classmethod
+    def from_problem(cls, domainproblem: "DomainProblem") -> "DurativeState":
+        """Build the initial durative state from a parsed ``DomainProblem``."""
+        return cls(domainproblem.initialstate())
+
+    def applicable(self, action: "DurativeAction") -> bool:
+        """True if the grounded ``action`` can *start* in this state.
+
+        Checks only the ``at start`` conditions (positive atoms hold, negative
+        atoms do not). ``over all`` / ``at end`` conditions are not evaluated —
+        that needs a timeline this type intentionally does not model.
+        """
+        pos = {atom_tuple(a) for a in action.condition_pos["start"]}
+        neg = {atom_tuple(a) for a in action.condition_neg["start"]}
+        return pos <= self._atoms and neg.isdisjoint(self._atoms)
+
+    def __contains__(self, atom: Any) -> bool:
+        return atom_tuple(atom) in self._atoms
+
+    def __iter__(self) -> Iterator[GroundAtom]:
+        return iter(self._atoms)
+
+    def __len__(self) -> int:
+        return len(self._atoms)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, DurativeState) and self._atoms == other._atoms
+
+    def __hash__(self) -> int:
+        return hash(self._atoms)
+
+    def __repr__(self) -> str:
+        return "DurativeState(%s)" % sorted(self._atoms)

--- a/tests/test_durative_state.py
+++ b/tests/test_durative_state.py
@@ -1,0 +1,155 @@
+"""#23: durative-action validation + `at start` applicability (DurativeState).
+
+These exercise the semantic layer above the durative object model — structural
+validation and start-condition applicability — without any temporal planning,
+which stays out of scope.
+"""
+import os
+
+import pytest
+
+from pddlpy import DomainProblem
+from pddlpy.pddl import Atom, DurativeAction
+from pddlpy.planning import (
+    DurativeState,
+    DurativeValidationError,
+    validate_durative_action,
+    validate_durative_actions,
+)
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _dp():
+    return DomainProblem(
+        os.path.join(CORPUS, "durative-action-domain.pddl"),
+        os.path.join(CORPUS, "durative-action-problem.pddl"),
+    )
+
+
+def _grounded(dp, **binding):
+    for g in dp.ground_durative_operator("go"):
+        if g.variable_list == binding:
+            return g
+    raise AssertionError("no grounding %r" % binding)
+
+
+def _synthetic(duration=1.0):
+    """A grounded-style durative action touching every condition/effect bucket
+    (predicates 'at'/'road'/'visited', no free variables)."""
+    da = DurativeAction("full")
+    da.duration = duration
+    da.condition_pos["start"] = {("at", "a")}
+    da.condition_pos["over"] = {("road", "a", "b")}
+    da.condition_pos["end"] = {("road", "a", "b")}
+    da.condition_neg["start"] = {("visited", "a")}
+    da.effect_pos["end"] = {("at", "b"), ("visited", "b")}
+    da.effect_neg["start"] = {("at", "a")}
+    return da
+
+
+# -- predicates() accessor ------------------------------------------------
+def test_predicates_accessor():
+    assert _dp().predicates() == {"at", "visited", "road"}
+
+
+# -- DurativeState --------------------------------------------------------
+def test_from_problem_atoms():
+    ds = DurativeState.from_problem(_dp())
+    assert ("at", "a") in ds
+    assert ("road", "a", "b") in ds
+    assert ("at", "b") not in ds
+    assert len(ds) == 2
+    assert set(ds) == {("at", "a"), ("road", "a", "b")}
+    assert ds.atoms == frozenset({("at", "a"), ("road", "a", "b")})
+
+
+def test_applicable_at_start_true():
+    dp = _dp()
+    ds = DurativeState.from_problem(dp)
+    assert ds.applicable(_grounded(dp, **{"?from": "a", "?to": "b"})) is True
+
+
+def test_applicable_at_start_false_missing_positive():
+    dp = _dp()
+    ds = DurativeState.from_problem(dp)
+    # go b->a needs (at b) at start, which the init lacks.
+    assert ds.applicable(_grounded(dp, **{"?from": "b", "?to": "a"})) is False
+
+
+def test_applicable_blocked_by_negative_start_condition():
+    da = DurativeAction("neg")
+    da.duration = 1.0
+    da.condition_neg["start"] = {("at", "a")}
+    assert DurativeState({("at", "a")}).applicable(da) is False
+    assert DurativeState(set()).applicable(da) is True
+
+
+def test_applicable_ignores_over_and_end():
+    # An action whose only over/end conditions are unmet is still start-applicable.
+    da = DurativeAction("oe")
+    da.duration = 1.0
+    da.condition_pos["over"] = {("never", "x")}
+    da.condition_pos["end"] = {("never", "y")}
+    assert DurativeState(set()).applicable(da) is True
+
+
+def test_state_normalizes_atom_objects_and_equality():
+    a = DurativeState([Atom(["at", "a"])])
+    b = DurativeState({("at", "a")})
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != DurativeState(set())
+    assert a != "not-a-state"
+    assert repr(a) == "DurativeState([('at', 'a')])"
+
+
+# -- validation -----------------------------------------------------------
+def test_validate_grounded_action_standalone():
+    dp = _dp()
+    # No declared_predicates -> only duration/parameter checks; must not raise.
+    validate_durative_action(_grounded(dp, **{"?from": "a", "?to": "b"}))
+
+
+def test_validate_full_action_with_predicates():
+    validate_durative_action(_synthetic(), {"at", "road", "visited"})
+
+
+def test_validate_all_durative_actions_ok():
+    validate_durative_actions(_dp())  # must not raise
+
+
+def test_validate_non_durative_domain_is_noop():
+    dp = DomainProblem(
+        os.path.join(CORPUS, "blocksworld-domain.pddl"),
+        os.path.join(CORPUS, "blocksworld-problem.pddl"),
+    )
+    validate_durative_actions(dp)  # no durative actions -> no-op
+
+
+def test_validate_missing_duration():
+    da = _synthetic(duration=None)
+    with pytest.raises(DurativeValidationError, match="no simple numeric duration"):
+        validate_durative_action(da)
+
+
+@pytest.mark.parametrize("bad", [0, -5.0])
+def test_validate_non_positive_duration(bad):
+    with pytest.raises(DurativeValidationError, match="non-positive duration"):
+        validate_durative_action(_synthetic(duration=bad))
+
+
+def test_validate_undeclared_predicate():
+    da = _synthetic()
+    da.condition_pos["start"] = {("bogus", "a")}
+    with pytest.raises(DurativeValidationError, match="undeclared predicate 'bogus'"):
+        validate_durative_action(da, {"at", "road", "visited"})
+
+
+def test_validate_undeclared_parameter():
+    da = DurativeAction("free")
+    da.duration = 1.0
+    da.variable_list = {"?from": None}
+    da.condition_pos["start"] = {Atom(["at", "?to"])}  # ?to not a parameter
+    with pytest.raises(DurativeValidationError, match="undeclared parameter '\\?to'"):
+        validate_durative_action(da)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,25 @@
+"""Smoke test: every example script under examples/ runs without error.
+
+Keeps the #80 showcase honest — examples are executed as ``__main__`` (so their
+in-script assertions run too) and must complete cleanly.
+"""
+import contextlib
+import glob
+import io
+import os
+import runpy
+
+import pytest
+
+EXAMPLES_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "examples")
+SCRIPTS = sorted(glob.glob(os.path.join(EXAMPLES_DIR, "[0-9][0-9]_*.py")))
+
+
+def test_examples_present():
+    assert SCRIPTS, "no example scripts found under examples/"
+
+
+@pytest.mark.parametrize("script", SCRIPTS, ids=[os.path.basename(s) for s in SCRIPTS])
+def test_example_runs(script):
+    with contextlib.redirect_stdout(io.StringIO()):
+        runpy.run_path(script, run_name="__main__")

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -2,9 +2,9 @@
 
 - #16 (`No module named '__builtin__'`): Python 2 leftover. Confirmed gone
   on 3.11+; guarded so it cannot creep back in.
-- #27 / #23: user-supplied durative-action files fail to parse. Confirmed a
-  duplicate of #23 (durative-action recovery is incomplete); xfail until
-  Phase 4 implements it.
+- #27 / #23: user-supplied durative-action files used to fail to parse.
+  Confirmed a duplicate of #23; now fixed — durative actions parse into the
+  DurativeAction model (see test_durative*.py for the full coverage).
 """
 import os
 


### PR DESCRIPTION
## Summary

Work toward the **1.0** release (release/publish itself, #81, is a separate PR). Re-scopes
the planning docs to reflect the already-shipped classical core, adds the durative
semantic layer, builds an example showcase, and clears the issue tracker.

The suite stays at **150 passing / 100% line coverage** throughout.

## What's in here

**#23 — durative validation + `at start` applicability** (`581db86`)
- New `pddlpy/planning/durative.py`: a small dedicated `DurativeState` that answers only
  "do this grounded durative action's `at start` conditions hold?" — **no timeline, no
  scheduler, no temporal planner** (solving durative domains stays out of scope).
- `validate_durative_action` / `validate_durative_actions` + `DurativeValidationError`
  (positive duration; parameters and predicates declared).
- `DomainProblem.predicates()` accessor.
- `tests/test_durative_state.py` (16 tests); `durative.py` at 100% coverage.

**#80 — example showcase + README chapter** (`3167dff`)
- `examples/`: six self-contained, runnable scripts of increasing complexity (parsing,
  type hierarchies, logical operators, planners, numeric+costs, durative) over bundled
  PDDL in `examples/pddl/`.
- README "Example showcase" chapter with a table linking each.
- `make examples` target; `tests/test_examples.py` runs every example as `__main__`.

**Docs** (`c20c7db`, `67fd3c0`)
- PRD/TODO re-scoped as "Road to 1.0" (the prior foundation-first draft predated the
  already-merged planner/numeric/costs/type-hierarchy work).

## Issue triage (done alongside this branch)
- Closed (verified fixed on `main`): #36, #16, #19, #21, #26, #27.
- Scoped to new milestones: #10 → **2.0** (ADL), #35 → **3.0** (HDDL).

## Out of scope
- #81 (version bump to 1.0.0, QA, PyPI publish) — separate PR.
- A temporal planner for durative solving; full ADL (#10); HDDL (#35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)