### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to `pddlpy` are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [1.0.0] - 2026-06-21
+
+First stable release. The library grew from a STRIPS parser into a parser +
+object model + a small, strictly-layered reference planning layer, with a stable
+public API (`Development Status :: 5 - Production/Stable`).
+
+### Added
+- **Planning layer** (`pddlpy.planning`): immutable `State` / `Plan`, `GroundedTask`,
+  a `Planner` ABC + `registry`, and four reference planners — `bfs`, `astar`,
+  `gbfs`, `ucs` (#1).
+- **Capability negotiation**: planners declare supported `:requirements` and fail
+  fast with `UnsupportedRequirementsError` on unsupported domains; `:requirements`
+  enforcement against used features (#9).
+- **Numeric fluents**: `:functions`, numeric preconditions/effects, and a numeric
+  valuation carried by `State` (#11).
+- **Action costs**: `total-cost`, `(:metric ...)`, `Plan.cost`, and cost-optimal
+  `UniformCostPlanner` (#3).
+- **Type hierarchies**: multi-level `:types` captured (`types()` / `subtypes_of()`);
+  a supertype parameter binds objects of any transitive subtype (#22).
+- **Pluggable variable binding**: `StaticPrunedBinder` (default) and `CartesianBinder`
+  (#12).
+- **Durative actions**: parsed and grounded into a `DurativeAction` model
+  (time-tagged `at start` / `over all` / `at end`), plus `DurativeState` `at start`
+  applicability and `validate_durative_action[s]` (#23). Temporal *solving* is out of
+  scope (tracked in #84).
+- **`DomainProblem.predicates()`** accessor.
+- **Example showcase** (`examples/`) and a README chapter; `make examples`.
+
+### Changed
+- PDDL keywords are now **case-insensitive**, so standard IPC files parse (#20, #36).
+- `Atom`/tuple state comparison resolved via the new `State` type — applicability and
+  goal checks no longer need manual casting (#21).
+
+### Fixed
+- Trailing line comment without a final newline no longer breaks parsing (#19).
+- Grounding is keyed per operator; grounding one operator no longer reuses another's
+  bindings (#26).
+- Disjunctive (`or`) preconditions are no longer silently flattened to `and`; the
+  top-level connective is preserved (#13).
+- Removed a Python-2-only import path (#16).
+
+### Quality
+- 150 tests, 100% line coverage; layering between grammar / model / planner enforced
+  by a test. Python 3.11+.
+
+[1.0.0]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ typecheck: pyparser pddlpy/pddl.py
 # Build distribution with uv
 build: test
 	@echo "Building distribution..."
+	rm -rf dist/
 	$(UV) build
 
 # Clean build artifacts
@@ -96,14 +97,17 @@ testpublish:
 	@echo ""
 	@echo "✓ TestPyPI installation test completed"
 
-# Publishing targets (kept for backwards compatibility)
+# Publishing targets. `build` rebuilds dist/ from scratch, so dist/* is exactly
+# the current version's sdist + wheel (both are uploaded, not just one).
 pypitest: build
 	@echo "Publishing to TestPyPI... (credentials in ~/.pypirc)"
-	$(UV) run twine upload --repository testpypi --verbose dist/`ls -t dist | head -1`
+	$(UV) run twine check dist/*
+	$(UV) run twine upload --repository testpypi --verbose dist/*
 
 pypipublish: build
 	@echo "Publishing to PyPI... (credentials in ~/.pypirc)"
-	$(UV) run twine upload --verbose dist/`ls -t dist | head -1`
+	$(UV) run twine check dist/*
+	$(UV) run twine upload --verbose dist/*
 
 # Help target
 help:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pddlpy"
-version = "0.4.5"
+version = "1.0.0"
 description = "Python PDDL parser"
 readme = "README.md"
 license = {text = "MIT"}
@@ -13,7 +13,7 @@ authors = [
 ]
 keywords = ["pddl", "planning", "parser"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: MIT License",

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,7 @@ wheels = [
 
 [[package]]
 name = "pddlpy"
-version = "0.4.5"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
Closes #81 (version bump + release tooling).

First stable release prep:
- `pyproject.toml`: `version` 0.4.5 → **1.0.0**; `Development Status` `3 - Alpha` →
  **5 - Production/Stable**. `uv.lock`: matching version.
- `Makefile`: `make build` now clears `dist/` first; `pypitest` / `pypipublish` upload
  **`dist/*`** (both sdist + wheel) and run `twine check` first — previously they uploaded
  only `` `ls -t dist | head -1` `` (the newest single file).
- `CHANGELOG.md`: 1.0.0 release notes (since 0.4.x).

No other file references the package version. Builds as `pddlpy-1.0.0` (sdist + wheel),
`twine check` passes both, 150 tests green.

**After merge**, publish (TestPyPI → verify → PyPI → tag `v1.0.0`) is run manually with the
maintainer's PyPI credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)