### PR TITLE
#85: pddlpy CLI — parse/ground/solve with JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,28 @@ registry.register('mine', MyPlanner)
 plan = registry.get('mine').solve(dp)
 ```
 
+### Command-line interface ###
+
+Installing the package also installs a `pddlpy` command (#85) with three
+subcommands, all emitting JSON on stdout — handy for shell pipelines and
+for agents that shouldn't have to write Python:
+
+```bash
+pddlpy parse  domain.pddl problem.pddl            # object-model summary
+pddlpy ground domain.pddl problem.pddl pick-up    # grounded instances of one action
+pddlpy solve  domain.pddl problem.pddl --planner ucs
+```
+
+`solve` defaults to `astar`; `--planner` accepts any registered planner
+(`bfs`, `astar`, `gbfs`, `ucs`). Exit codes: `0` success, `1` search
+completed without finding a plan, `2` bad input (missing file, unknown
+operator, unsupported `:requirements`).
+
+```bash
+$ pddlpy solve blocksworld-domain.pddl blocksworld-problem.pddl | jq .cost
+4
+```
+
 ### Documentation ###
 
 * [`docs/object-model.md`](docs/object-model.md) — full reference for the

--- a/pddlpy/cli.py
+++ b/pddlpy/cli.py
@@ -1,0 +1,89 @@
+"""Command-line interface (#85): drive pddlpy without writing Python.
+
+Three subcommands over a domain/problem pair, all emitting JSON on stdout:
+
+    pddlpy parse  DOMAIN PROBLEM             # object-model summary
+    pddlpy ground DOMAIN PROBLEM OPERATOR    # grounded instances of one action
+    pddlpy solve  DOMAIN PROBLEM [--planner NAME]
+
+Exit codes: 0 success; 1 solve ran but found no plan; 2 bad input
+(missing file, unknown operator/planner, unsupported :requirements).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List, Optional
+
+from pddlpy.pddl import DomainProblem
+from pddlpy.planning import PlannerError, get, registry
+from pddlpy.serialize import domain_problem_dict, operator_dict, plan_dict
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pddlpy",
+        description="Parse, ground and solve PDDL domain/problem pairs (JSON output).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_ in (
+        ("parse", "summarize the parsed domain/problem pair"),
+        ("ground", "list the grounded instances of one operator"),
+        ("solve", "search for a plan"),
+    ):
+        cmd = sub.add_parser(name, help=help_)
+        cmd.add_argument("domain", help="path to the domain PDDL file")
+        cmd.add_argument("problem", help="path to the problem PDDL file")
+        if name == "ground":
+            cmd.add_argument("operator", help="operator name to ground")
+        if name == "solve":
+            cmd.add_argument(
+                "--planner",
+                default="astar",
+                choices=registry.names(),
+                help="planner to use (default: astar)",
+            )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        dp = DomainProblem(args.domain, args.problem)
+    except FileNotFoundError as exc:
+        print("pddlpy: error: %s" % exc, file=sys.stderr)
+        return 2
+
+    if args.command == "parse":
+        result = domain_problem_dict(dp)
+    elif args.command == "ground":
+        if args.operator not in dp.operators():
+            print(
+                "pddlpy: error: unknown operator %r; known: %s"
+                % (args.operator, sorted(dp.operators())),
+                file=sys.stderr,
+            )
+            return 2
+        result = {
+            "operator": args.operator,
+            "groundings": [operator_dict(op) for op in dp.ground_operator(args.operator)],
+        }
+    else:  # solve
+        try:
+            plan = get(args.planner).solve(dp)
+        except PlannerError as exc:
+            print("pddlpy: error: %s" % exc, file=sys.stderr)
+            return 2
+        result = {"planner": args.planner, **plan_dict(plan)}
+        print(json.dumps(result, indent=2))
+        return 0 if plan is not None else 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/pddlpy/serialize.py
+++ b/pddlpy/serialize.py
@@ -1,0 +1,73 @@
+"""JSON-friendly views of the object model (#85).
+
+Plain-dict renderings of ``DomainProblem``, grounded ``Operator`` and
+``Plan``, shared by the command-line interface (#85) and the MCP server
+(#86). Everything returned is composed of JSON-serializable types only:
+atoms become sorted lists of token lists, sets become sorted lists, and
+numeric expressions are rendered through their ``repr``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from pddlpy.pddl import DomainProblem, Operator
+from pddlpy.planning import Plan, atom_tuple
+
+
+def atoms_list(atoms: Iterable[Any]) -> List[List[str]]:
+    """Render a collection of atoms/tuples as a sorted list of token lists."""
+    return sorted(list(atom_tuple(a)) for a in atoms)
+
+
+def domain_problem_dict(dp: DomainProblem) -> Dict[str, Any]:
+    """Summary of a parsed domain/problem pair."""
+    metric = dp.metric()
+    return {
+        "requirements": sorted(dp.requirements()),
+        "objects": dict(sorted(dp.worldobjects().items())),
+        "types": dict(sorted(dp.types().items())),
+        "predicates": sorted(dp.predicates()),
+        "operators": sorted(dp.operators()),
+        "durative_operators": sorted(dp.durative_operators()),
+        "initial_state": atoms_list(dp.initialstate()),
+        "goals": atoms_list(dp.goals()),
+        "initial_numeric": {
+            " ".join(head): value
+            for head, value in sorted(dp.initial_numeric().items())
+        },
+        "metric": (
+            {"optimization": metric[0], "expression": metric[1]}
+            if metric is not None
+            else None
+        ),
+    }
+
+
+def operator_dict(op: Operator) -> Dict[str, Any]:
+    """A grounded instantaneous action."""
+    return {
+        "name": op.operator_name,
+        "parameters": dict(op.variable_list),
+        "precondition_connective": op.precondition_connective,
+        "precondition_pos": atoms_list(op.precondition_pos),
+        "precondition_neg": atoms_list(op.precondition_neg),
+        "effect_pos": atoms_list(op.effect_pos),
+        "effect_neg": atoms_list(op.effect_neg),
+        "precondition_num": [repr(c) for c in op.precondition_num],
+        "effect_num": [repr(e) for e in op.effect_num],
+    }
+
+
+def plan_dict(plan: Optional[Plan]) -> Dict[str, Any]:
+    """A plan (or the absence of one, when ``plan`` is ``None``)."""
+    if plan is None:
+        return {"solved": False, "cost": None, "length": None, "steps": None}
+    return {
+        "solved": True,
+        "cost": plan.cost,
+        "length": len(plan),
+        "steps": [
+            {"action": name, "args": dict(bindings)}
+            for name, bindings in plan.action_names()
+        ],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "antlr4-python3-runtime==4.13.2",
 ]
 
+[project.scripts]
+pddlpy = "pddlpy.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/hfoffani/pddl-lib"
 Repository = "https://github.com/hfoffani/pddl-lib"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,150 @@
+"""The pddlpy CLI (#85): parse / ground / solve emit JSON with sane exit codes."""
+import json
+import os
+
+import pytest
+
+from pddlpy.cli import main
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _files(name):
+    return (
+        os.path.join(CORPUS, "%s-domain.pddl" % name),
+        os.path.join(CORPUS, "%s-problem.pddl" % name),
+    )
+
+
+def _run(capsys, *argv):
+    code = main(list(argv))
+    captured = capsys.readouterr()
+    out = json.loads(captured.out) if captured.out else None
+    return code, out, captured.err
+
+
+# --- parse ---------------------------------------------------------------
+
+def test_parse_summary(capsys):
+    code, out, err = _run(capsys, "parse", *_files("blocksworld"))
+    assert code == 0 and err == ""
+    assert "pick-up" in out["operators"]
+    assert out["durative_operators"] == []
+    assert ["handempty"] in out["initial_state"]
+    assert ["on", "a", "b"] in out["goals"]
+    assert out["metric"] is None
+    assert out["initial_numeric"] == {}
+    assert out["objects"]["a"] is None  # untyped domain
+
+
+def test_parse_numeric_metric_and_types(capsys):
+    code, out, err = _run(capsys, "parse", *_files("travel"))
+    assert code == 0
+    assert out["metric"] == {"optimization": "minimize", "expression": "(total-cost)"}
+    assert out["initial_numeric"]["total-cost"] == 0.0
+    assert out["types"] == {"place": None}
+    assert ":action-costs" in out["requirements"]
+    assert "at" in out["predicates"]
+
+
+def test_parse_durative(capsys):
+    code, out, _ = _run(capsys, "parse", *_files("durative-action"))
+    assert code == 0
+    assert out["durative_operators"] == ["go"]
+
+
+def test_parse_missing_file(capsys):
+    code, out, err = _run(capsys, "parse", "nosuch-domain.pddl", "nosuch-problem.pddl")
+    assert code == 2 and out is None
+    assert "pddlpy: error:" in err
+
+
+# --- ground --------------------------------------------------------------
+
+def test_ground_operator(capsys):
+    code, out, _ = _run(capsys, "ground", *_files("blocksworld"), "pick-up")
+    assert code == 0
+    assert out["operator"] == "pick-up"
+    groundings = out["groundings"]
+    g = next(g for g in groundings if g["parameters"] == {"?x": "a"})
+    assert g["name"] == "pick-up"
+    assert g["precondition_connective"] == "and"
+    assert list(g["parameters"]) == ["?x"]
+    assert ["handempty"] in g["precondition_pos"]
+    assert ["holding", g["parameters"]["?x"]] in g["effect_pos"]
+
+
+def test_ground_numeric_reprs(capsys):
+    code, out, _ = _run(capsys, "ground", *_files("numeric-transport"), "drive")
+    assert code == 0
+    g = out["groundings"][0]
+    assert any(">=" in c for c in g["precondition_num"])
+    assert any("decrease" in e for e in g["effect_num"])
+
+
+def test_ground_unknown_operator(capsys):
+    code, out, err = _run(capsys, "ground", *_files("blocksworld"), "fly")
+    assert code == 2 and out is None
+    assert "unknown operator 'fly'" in err and "pick-up" in err
+
+
+# --- solve ---------------------------------------------------------------
+
+def test_solve_default_planner(capsys):
+    code, out, _ = _run(capsys, "solve", *_files("blocksworld"))
+    assert code == 0
+    assert out["planner"] == "astar" and out["solved"] is True
+    assert out["length"] == len(out["steps"]) > 0
+    step = out["steps"][0]
+    assert set(step) == {"action", "args"}
+
+
+def test_solve_cost_aware(capsys):
+    code, out, _ = _run(capsys, "solve", *_files("travel"), "--planner", "ucs")
+    assert code == 0
+    assert out["solved"] is True and out["cost"] > 0
+
+
+def test_solve_no_plan(capsys, tmp_path):
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(
+        "(define (domain toy) (:predicates (p) (q))"
+        " (:action a :parameters () :precondition (q) :effect (p)))"
+    )
+    problem.write_text(
+        "(define (problem t1) (:domain toy) (:init) (:goal (p)))"
+    )
+    code, out, _ = _run(capsys, "solve", str(domain), str(problem), "--planner", "bfs")
+    assert code == 1
+    assert out == {
+        "planner": "bfs", "solved": False, "cost": None, "length": None, "steps": None,
+    }
+
+
+def test_solve_unsupported_requirements(capsys, tmp_path):
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(
+        "(define (domain toy) (:requirements :adl) (:predicates (p))"
+        " (:action a :parameters () :precondition (p) :effect (p)))"
+    )
+    problem.write_text(
+        "(define (problem t1) (:domain toy) (:init (p)) (:goal (p)))"
+    )
+    code, out, err = _run(capsys, "solve", str(domain), str(problem))
+    assert code == 2 and out is None
+    assert "pddlpy: error:" in err
+
+
+def test_solve_unknown_planner_rejected_by_argparse(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["solve", *_files("blocksworld"), "--planner", "nosuch"])
+    assert exc.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_missing_subcommand_rejected(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main([])
+    assert exc.value.code == 2


### PR DESCRIPTION
Closes #85.

## What
A `pddlpy` console command (installed with the package) that parses, grounds, and solves PDDL domain/problem pairs from the shell, emitting JSON.

## Why
Until now the library required writing Python. A CLI makes it usable from shell pipelines and by agents/tools that shouldn't have to embed Python — and it's the foundation the MCP server (#86) builds on.

## Changes
- **pddlpy/serialize.py** — JSON-friendly dict renderings of `DomainProblem` (requirements, objects, types, predicates, operators, initial state, goals, numeric init, metric), grounded `Operator`, and `Plan`. Kept separate from the CLI so #86 can reuse it.
- **pddlpy/cli.py** — stdlib `argparse`, three subcommands:
  - `pddlpy parse DOMAIN PROBLEM` — object-model summary
  - `pddlpy ground DOMAIN PROBLEM OPERATOR` — grounded instances of one action
  - `pddlpy solve DOMAIN PROBLEM [--planner NAME]` — defaults to `astar`; `--planner` choices come from the live registry
  - Exit codes: `0` success, `1` search found no plan, `2` bad input (missing file, unknown operator/planner, unsupported `:requirements`)
- **pyproject.toml** — `[project.scripts] pddlpy = "pddlpy.cli:main"`
- **tests/test_cli.py** — 13 tests covering every subcommand and error path
- **README.md** — new "Command-line interface" section

## Reviewer notes
- No new dependencies (stdlib argparse, per YAGNI).
- Suite: 163 passed, coverage 100% (both new modules fully covered); ruff and mypy clean.
- Smoke-tested the installed entry point: `uv run pddlpy solve tests/corpus/travel-domain.pddl ... --planner ucs` returns the cost-2 plan.
- Stacked PR for #86 (MCP server) will target this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)