### PR TITLE
docs(skill): teach the agent skill the CLI fast path

### DIFF
--- a/skills/pddlpy/SKILL.md
+++ b/skills/pddlpy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pddlpy
-description: Parse PDDL domain/problem files and solve them with pddlpy. Use when working with PDDL planning files — parsing a domain/problem, inspecting the initial state/goals/operators, grounding actions, evaluating numeric fluents or action costs, or running a reference planner (BFS/A*/GBFS/UCS) to produce a plan.
+description: Parse PDDL domain/problem files and solve them with pddlpy, via the pddlpy CLI (JSON output) or the Python API. Use when working with PDDL planning files — parsing a domain/problem, inspecting the initial state/goals/operators, grounding actions, evaluating numeric fluents or action costs, or running a reference planner (BFS/A*/GBFS/UCS) to produce a plan.
 ---
 
 # pddlpy
@@ -16,6 +16,26 @@ uv sync          # install (project uses uv)
 ```
 
 Import: `from pddlpy import DomainProblem` and `from pddlpy.planning import get`.
+
+## Quick path: the CLI (no Python needed)
+
+Installing the package also installs a `pddlpy` command (#85). For one-off
+parse/ground/solve questions, prefer it over writing Python — JSON on stdout,
+pipeable to `jq`:
+
+```bash
+pddlpy parse  domain.pddl problem.pddl              # object-model summary
+pddlpy ground domain.pddl problem.pddl move         # grounded instances of one action
+pddlpy solve  domain.pddl problem.pddl --planner ucs   # default planner: astar
+```
+
+In this repo run it as `uv run pddlpy ...`; outside, `uvx pddlpy ...` works
+once a release containing the CLI is on PyPI. Exit codes: `0` success, `1`
+search found no plan, `2` bad input (missing file, unknown operator/planner,
+unsupported `:requirements`). Drop to the Python API below when you need
+`State`/`GroundedTask`, custom binders, or anything the three subcommands
+don't cover. (There is also an MCP server, `pddlpy-mcp`, exposing the same
+three operations as tools — `pip install "pddlpy[mcp]"`.)
 
 ## Parse a domain + problem
 
@@ -75,9 +95,9 @@ s.applicable(op); s.apply(op)              # no manual Atom/tuple casting
 - `initialstate()`/`goals()` return `Atom` objects with **no value equality**.
   A grounded operator's pre/effects are plain tuples. Normalize with
   `from pddlpy.planning import atom_tuple` (or compare `repr`s / use `State`).
-- **Type hierarchies (#22):** grounding matches a parameter's declared type
-  exactly — multi-level hierarchies (e.g. logistics) do not fully ground.
-  Untyped (blocksworld) and single-level typed (gripper) domains work.
+- **Type hierarchies (#22)** are supported: a parameter typed with a supertype
+  binds objects of any transitive subtype (`dp.types()` / `dp.subtypes_of(t)`
+  expose the hierarchy). Only `(either ...)` union types are unhandled.
 - **Durative actions** (`:durative-actions`) parse into `DurativeAction`
   (`dp.durative_operators()`), but the reference planners are non-temporal and
   will not solve them.


### PR DESCRIPTION
## What
Update `skills/pddlpy/SKILL.md` so agents know pddlpy is now drivable from a shell command, not just the Python API.

## Why
The skill predates #85/#86: an agent following it writes a Python script even for a one-off "what's the plan for this domain/problem" question that `pddlpy solve` answers in one line of shell with JSON output.

## Changes
- New **"Quick path: the CLI"** section right after Setup: the three subcommands, default planner, exit codes, `uv run pddlpy` (in-repo) vs `uvx pddlpy` (post-release) forms, and when to drop down to the Python API; one-line pointer to `pddlpy-mcp`
- Frontmatter description now mentions the CLI so the skill triggers on shell-oriented requests too
- Fixed a stale gotcha: it still claimed multi-level type hierarchies (#22) don't ground — they do since #78; only `(either ...)` union types remain unhandled

Verified the documented commands run as written against the test corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)