### PR TITLE
#94: validate — PDDL diagnostics for agent-emitted translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,15 +215,24 @@ subcommands, all emitting JSON on stdout — handy for shell pipelines and
 for agents that shouldn't have to write Python:
 
 ```bash
-pddlpy parse  domain.pddl problem.pddl            # object-model summary
-pddlpy ground domain.pddl problem.pddl pick-up    # grounded instances of one action
-pddlpy solve  domain.pddl problem.pddl --planner ucs
+pddlpy parse    domain.pddl problem.pddl            # object-model summary
+pddlpy ground   domain.pddl problem.pddl pick-up    # grounded instances of one action
+pddlpy solve    domain.pddl problem.pddl --planner ucs
+pddlpy validate domain.pddl problem.pddl            # diagnostics (see below)
 ```
 
 `solve` defaults to `astar`; `--planner` accepts any registered planner
 (`bfs`, `astar`, `gbfs`, `ucs`). Exit codes: `0` success, `1` search
-completed without finding a plan, `2` bad input (missing file, unknown
-operator, unsupported `:requirements`).
+completed without finding a plan / `validate` found issues, `2` bad input
+(missing file, unknown operator, unsupported `:requirements`).
+
+`validate` (#94) checks a pair for the mistakes that typically slip through
+a bare parse — collected syntax errors (ANTLR error-recovers, so `parse`
+alone won't stop on them), atoms over undeclared predicates, ground atoms
+naming unknown objects, operators grounding to zero instances, and malformed
+durative actions. It reports `{valid, issues: [{severity, check, message}]}`
+and is designed as the feedback step of an agentic write-PDDL → validate →
+fix → solve loop (e.g. translating a natural-language problem to PDDL).
 
 ```bash
 $ pddlpy solve blocksworld-domain.pddl blocksworld-problem.pddl | jq .cost
@@ -233,9 +242,9 @@ $ pddlpy solve blocksworld-domain.pddl blocksworld-problem.pddl | jq .cost
 ### MCP server ###
 
 For LLMs and agents, pddlpy ships a [Model Context Protocol](https://modelcontextprotocol.io)
-server (#86) exposing the same three operations as tools — `parse`, `ground`
-and `solve` — with structured JSON results. It is the runtime counterpart of
-the static Agent Skill in [`skills/pddlpy/`](skills/pddlpy/SKILL.md).
+server (#86) exposing the same operations as tools — `parse`, `ground`,
+`solve` and `validate` — with structured JSON results. It is the runtime
+counterpart of the static Agent Skill in [`skills/pddlpy/`](skills/pddlpy/SKILL.md).
 
 ```bash
 pip install "pddlpy[mcp]"    # the mcp SDK is an optional extra
@@ -253,7 +262,9 @@ Client configuration (e.g. Claude Desktop / Claude Code):
 ```
 
 Tools take filesystem paths to the domain/problem files; `solve` accepts an
-optional `planner` argument (`bfs`, `astar`, `gbfs`, `ucs`).
+optional `planner` argument (`bfs`, `astar`, `gbfs`, `ucs`). For agents
+translating natural language to PDDL, `validate` provides the fix-loop
+feedback (syntax, undeclared predicates, unknown objects, zero groundings).
 
 ### Documentation ###
 

--- a/pddlpy/cli.py
+++ b/pddlpy/cli.py
@@ -2,12 +2,14 @@
 
 Three subcommands over a domain/problem pair, all emitting JSON on stdout:
 
-    pddlpy parse  DOMAIN PROBLEM             # object-model summary
-    pddlpy ground DOMAIN PROBLEM OPERATOR    # grounded instances of one action
-    pddlpy solve  DOMAIN PROBLEM [--planner NAME]
+    pddlpy parse    DOMAIN PROBLEM             # object-model summary
+    pddlpy ground   DOMAIN PROBLEM OPERATOR    # grounded instances of one action
+    pddlpy solve    DOMAIN PROBLEM [--planner NAME]
+    pddlpy validate DOMAIN PROBLEM             # diagnostics (#94)
 
-Exit codes: 0 success; 1 solve ran but found no plan; 2 bad input
-(missing file, unknown operator/planner, unsupported :requirements).
+Exit codes: 0 success; 1 solve found no plan / validate found issues;
+2 bad input (missing file, unknown operator/planner, unsupported
+:requirements).
 """
 from __future__ import annotations
 
@@ -16,6 +18,7 @@ import json
 import sys
 from typing import List, Optional
 
+from pddlpy.diagnostics import diagnose
 from pddlpy.pddl import DomainProblem
 from pddlpy.planning import PlannerError, get, registry
 from pddlpy.serialize import domain_problem_dict, operator_dict, plan_dict
@@ -32,6 +35,7 @@ def build_parser() -> argparse.ArgumentParser:
         ("parse", "summarize the parsed domain/problem pair"),
         ("ground", "list the grounded instances of one operator"),
         ("solve", "search for a plan"),
+        ("validate", "check the pair for common translation errors"),
     ):
         cmd = sub.add_parser(name, help=help_)
         cmd.add_argument("domain", help="path to the domain PDDL file")
@@ -50,6 +54,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Optional[List[str]] = None) -> int:
     args = build_parser().parse_args(argv)
+
+    if args.command == "validate":
+        try:
+            result = diagnose(args.domain, args.problem)
+        except FileNotFoundError as exc:
+            print("pddlpy: error: %s" % exc, file=sys.stderr)
+            return 2
+        print(json.dumps(result, indent=2))
+        return 0 if not result["issues"] else 1
 
     try:
         dp = DomainProblem(args.domain, args.problem)

--- a/pddlpy/diagnostics.py
+++ b/pddlpy/diagnostics.py
@@ -1,0 +1,142 @@
+"""PDDL diagnostics (#94): machine-checkable validation of a domain/problem pair.
+
+Aimed at the agentic NL->PDDL loop: a parse that "succeeds" is not enough,
+because ANTLR error-recovers (syntax errors only go to stderr) and a
+semantically-off translation typically shows up as atoms over undeclared
+predicates, ground atoms naming unknown objects, or operators that ground
+to zero instances. :func:`diagnose` bundles those checks into one JSON-able
+verdict, shared by ``pddlpy validate`` (CLI, #85) and the ``validate`` MCP
+tool (#86).
+
+This module sits at the object-model layer: like ``pddlpy.pddl`` it may
+import the generated grammar (the planning layer may not).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, Set, Tuple
+
+from antlr4 import CommonTokenStream, FileStream
+from antlr4.error.ErrorListener import ErrorListener
+
+from pddlpy.pddl import DomainProblem
+from pddlpy.pddlLexer import pddlLexer
+from pddlpy.pddlParser import pddlParser
+from pddlpy.planning import DurativeValidationError, atom_tuple, validate_durative_actions
+
+
+class _CollectingErrorListener(ErrorListener):
+    """Accumulates ANTLR syntax errors instead of printing them to stderr."""
+
+    def __init__(self) -> None:
+        self.errors: List[str] = []
+
+    def syntaxError(self, recognizer: Any, offendingSymbol: Any, line: int,
+                    column: int, msg: str, e: Any) -> None:
+        self.errors.append("line %d:%d %s" % (line, column, msg))
+
+
+def _syntax_errors(path: str, rule: str) -> List[str]:
+    """Parse ``path`` with the grammar rule ``rule`` ('domain' or 'problem')
+    and return the collected syntax errors."""
+    collector = _CollectingErrorListener()
+    lexer = pddlLexer(FileStream(path))
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(collector)
+    parser = pddlParser(CommonTokenStream(lexer))
+    parser.removeErrorListeners()
+    parser.addErrorListener(collector)
+    getattr(parser, rule)()
+    return collector.errors
+
+
+def _condition_atoms(dp: DomainProblem) -> Iterator[Tuple[str, Any]]:
+    """Yield ``(where, atom)`` for every atom referenced by the model:
+    init, goal, and each (durative) action's conditions and effects."""
+    for atom in dp.initialstate():
+        yield ":init", atom
+    for atom in dp.goals():
+        yield ":goal", atom
+    for name, op in dp.domain.operators.items():
+        for group in (op.precondition_pos, op.precondition_neg,
+                      op.effect_pos, op.effect_neg):
+            for atom in group:
+                yield "action %r" % name, atom
+    for name, dop in dp.domain.durative_operators.items():
+        for timed in (dop.condition_pos, dop.condition_neg):
+            for atoms in timed.values():
+                for atom in atoms:
+                    yield "durative action %r" % name, atom
+        for timed in (dop.effect_pos, dop.effect_neg):
+            for atoms in timed.values():
+                for atom in atoms:
+                    yield "durative action %r" % name, atom
+
+
+def _issue(severity: str, check: str, message: str) -> Dict[str, str]:
+    return {"severity": severity, "check": check, "message": message}
+
+
+def diagnose(domainfile: str, problemfile: str) -> Dict[str, Any]:
+    """Validate a domain/problem pair; returns ``{"valid": bool, "issues": [...]}``.
+
+    Each issue is ``{"severity": "error"|"warning", "check": ..., "message": ...}``.
+    ``valid`` is False when any error-severity issue is present (warnings —
+    currently only ``zero_groundings`` — leave the pair valid but suspicious).
+    On syntax errors the semantic checks are skipped: the recovered model
+    would produce misleading follow-on findings.
+    """
+    issues: List[Dict[str, str]] = []
+
+    for path, rule, which in ((domainfile, "domain", "domain file"),
+                              (problemfile, "problem", "problem file")):
+        for err in _syntax_errors(path, rule):
+            issues.append(_issue("error", "syntax", "%s: %s" % (which, err)))
+    if issues:
+        return {"valid": False, "issues": issues}
+
+    dp = DomainProblem(domainfile, problemfile)
+
+    # Atoms over predicates the domain never declares.
+    declared = dp.predicates()
+    if declared:
+        seen: Dict[str, Set[str]] = {}
+        for where, atom in _condition_atoms(dp):
+            pred = atom_tuple(atom)[0]
+            if pred not in declared:
+                seen.setdefault(pred, set()).add(where)
+        for pred in sorted(seen):
+            issues.append(_issue(
+                "error", "undeclared_predicate",
+                "predicate %r is not declared in :predicates (used in %s)"
+                % (pred, ", ".join(sorted(seen[pred])))))
+
+    # Ground atoms (init/goal) naming objects that were never declared.
+    objects = set(dp.worldobjects())
+    unknown: Dict[str, Set[str]] = {}
+    for where, atoms in ((":init", dp.initialstate()), (":goal", dp.goals())):
+        for atom in atoms:
+            for term in atom_tuple(atom)[1:]:
+                if term not in objects:
+                    unknown.setdefault(term, set()).add(where)
+    for term in sorted(unknown):
+        issues.append(_issue(
+            "error", "unknown_object",
+            "object %r is not declared in :objects (used in %s)"
+            % (term, ", ".join(sorted(unknown[term])))))
+
+    # Operators that ground to zero instances: legal, but in an agent-written
+    # translation almost always a mistyped object, type, or static predicate.
+    for name in sorted(dp.operators()):
+        if next(dp.ground_operator(name), None) is None:
+            issues.append(_issue(
+                "warning", "zero_groundings",
+                "operator %r grounds to zero instances" % name))
+
+    # Durative structure (duration positive, parameters/predicates declared).
+    try:
+        validate_durative_actions(dp)
+    except DurativeValidationError as exc:
+        issues.append(_issue("error", "durative", str(exc)))
+
+    valid = not any(i["severity"] == "error" for i in issues)
+    return {"valid": valid, "issues": issues}

--- a/pddlpy/mcpserver.py
+++ b/pddlpy/mcpserver.py
@@ -14,6 +14,7 @@ from typing import Any, Dict
 
 from mcp.server.fastmcp import FastMCP
 
+from pddlpy.diagnostics import diagnose
 from pddlpy.pddl import DomainProblem
 from pddlpy.planning import get, registry
 from pddlpy.serialize import domain_problem_dict, operator_dict, plan_dict
@@ -64,6 +65,16 @@ def solve(domain_file: str, problem_file: str, planner: str = "astar") -> Dict[s
     dp = DomainProblem(domain_file, problem_file)
     plan = get(planner).solve(dp)
     return {"planner": planner, **plan_dict(plan)}
+
+
+@server.tool()
+def validate(domain_file: str, problem_file: str) -> Dict[str, Any]:
+    """Check a PDDL domain/problem pair for common translation errors:
+    syntax errors, atoms over undeclared predicates, ground atoms naming
+    unknown objects, operators grounding to zero instances, and malformed
+    durative actions. Returns {valid, issues:[{severity, check, message}]}.
+    Run this after writing or editing PDDL, before ground/solve."""
+    return diagnose(domain_file, problem_file)
 
 
 def main() -> None:

--- a/skills/pddlpy/SKILL.md
+++ b/skills/pddlpy/SKILL.md
@@ -24,10 +24,18 @@ parse/ground/solve questions, prefer it over writing Python — JSON on stdout,
 pipeable to `jq`:
 
 ```bash
-pddlpy parse  domain.pddl problem.pddl              # object-model summary
-pddlpy ground domain.pddl problem.pddl move         # grounded instances of one action
-pddlpy solve  domain.pddl problem.pddl --planner ucs   # default planner: astar
+pddlpy parse    domain.pddl problem.pddl            # object-model summary
+pddlpy ground   domain.pddl problem.pddl move       # grounded instances of one action
+pddlpy solve    domain.pddl problem.pddl --planner ucs   # default planner: astar
+pddlpy validate domain.pddl problem.pddl            # diagnostics for PDDL you wrote
 ```
+
+**If you write or edit PDDL yourself** (e.g. translating a problem from
+natural language), run `validate` before `solve` and fix what it reports:
+it collects syntax errors (a bare parse error-recovers past them), atoms
+over undeclared predicates, unknown objects, operators grounding to zero
+instances, and malformed durative actions. Exit `0` = clean, `1` = issues
+in the JSON `issues` list.
 
 In this repo run it as `uv run pddlpy ...`; outside, `uvx pddlpy ...` works
 once a release containing the CLI is on PyPI. Exit codes: `0` success, `1`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,6 +137,36 @@ def test_solve_unsupported_requirements(capsys, tmp_path):
     assert "pddlpy: error:" in err
 
 
+# --- validate ------------------------------------------------------------
+
+def test_validate_clean_pair(capsys):
+    code, out, err = _run(capsys, "validate", *_files("blocksworld"))
+    assert code == 0 and err == ""
+    assert out == {"valid": True, "issues": []}
+
+
+def test_validate_reports_issues_with_exit_1(capsys, tmp_path):
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(
+        "(define (domain toy) (:predicates (p ?x))"
+        " (:action a :parameters (?x) :precondition (p ?x) :effect (r ?x)))"
+    )
+    problem.write_text(
+        "(define (problem t) (:domain toy) (:objects o1) (:init (p o1)) (:goal (p o1)))"
+    )
+    code, out, _ = _run(capsys, "validate", str(domain), str(problem))
+    assert code == 1
+    assert out["valid"] is False
+    assert out["issues"][0]["check"] == "undeclared_predicate"
+
+
+def test_validate_missing_file(capsys):
+    code, out, err = _run(capsys, "validate", "nosuch-d.pddl", "nosuch-p.pddl")
+    assert code == 2 and out is None
+    assert "pddlpy: error:" in err
+
+
 def test_solve_unknown_planner_rejected_by_argparse(capsys):
     with pytest.raises(SystemExit) as exc:
         main(["solve", *_files("blocksworld"), "--planner", "nosuch"])

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,108 @@
+"""PDDL diagnostics (#94): diagnose() flags what an agent must fix."""
+import os
+
+import pytest
+
+from pddlpy.diagnostics import diagnose
+
+CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
+
+
+def _files(name):
+    return (
+        os.path.join(CORPUS, "%s-domain.pddl" % name),
+        os.path.join(CORPUS, "%s-problem.pddl" % name),
+    )
+
+
+@pytest.fixture
+def w(tmp_path):
+    def write(name, text):
+        p = tmp_path / name
+        p.write_text(text)
+        return str(p)
+    return write
+
+
+GOOD_PROBLEM = "(define (problem t) (:domain toy) (:objects o1) (:init (p o1)) (:goal (r o1)))"
+
+
+def _checks(report):
+    return [(i["severity"], i["check"]) for i in report["issues"]]
+
+
+def test_clean_pair_is_valid():
+    report = diagnose(*_files("blocksworld"))
+    assert report == {"valid": True, "issues": []}
+
+
+def test_clean_durative_pair_is_valid():
+    assert diagnose(*_files("durative-action"))["valid"] is True
+
+
+def test_syntax_error_short_circuits(w):
+    dom = w("d.pddl", "(define (domain toy) (:predicates (p))"
+                      " (:action a :parameters () :precondition (p) :effect (p))")
+    prob = w("p.pddl", "(define (problem t) (:domain toy) (:init (p)) (:goal (p)))")
+    report = diagnose(dom, prob)
+    assert report["valid"] is False
+    assert _checks(report) == [("error", "syntax")]
+    assert "domain file: line 1:" in report["issues"][0]["message"]
+
+
+def test_undeclared_predicate(w):
+    dom = w("d.pddl", "(define (domain toy) (:predicates (p ?x))"
+                      " (:action a :parameters (?x) :precondition (p ?x) :effect (r ?x)))")
+    prob = w("p.pddl", "(define (problem t) (:domain toy) (:objects o1)"
+                       " (:init (p o1)) (:goal (p o1)))")
+    report = diagnose(dom, prob)
+    assert report["valid"] is False
+    assert ("error", "undeclared_predicate") in _checks(report)
+    assert "'r'" in report["issues"][0]["message"]
+    assert "action 'a'" in report["issues"][0]["message"]
+
+
+def test_unknown_object_in_goal(w):
+    dom = w("d.pddl", "(define (domain toy) (:predicates (p ?x))"
+                      " (:action a :parameters (?x) :precondition (p ?x) :effect (p ?x)))")
+    prob = w("p.pddl", "(define (problem t) (:domain toy) (:objects o1)"
+                       " (:init (p o1)) (:goal (p zz)))")
+    report = diagnose(dom, prob)
+    assert report["valid"] is False
+    assert ("error", "unknown_object") in _checks(report)
+    assert "'zz'" in report["issues"][0]["message"] and ":goal" in report["issues"][0]["message"]
+
+
+def test_zero_groundings_is_warning_only(w):
+    dom = w("d.pddl", "(define (domain toy) (:predicates (p ?x) (q ?x) (r ?x))"
+                      " (:action a :parameters (?x)"
+                      " :precondition (and (p ?x) (q ?x)) :effect (r ?x)))")
+    prob = w("p.pddl", GOOD_PROBLEM)  # no (q _) fact in :init
+    report = diagnose(dom, prob)
+    assert _checks(report) == [("warning", "zero_groundings")]
+    assert report["valid"] is True  # warning does not invalidate
+    assert "'a'" in report["issues"][0]["message"]
+
+
+def test_broken_durative_action(w):
+    dom = w("d.pddl", "(define (domain toy) (:requirements :durative-actions)"
+                      " (:predicates (p ?x))"
+                      " (:durative-action go :parameters (?x)"
+                      "  :duration (= ?duration 0)"
+                      "  :condition (and (at start (p ?x)))"
+                      "  :effect (and (at end (p ?x)))))")
+    prob = w("p.pddl", "(define (problem t) (:domain toy) (:objects o1)"
+                       " (:init (p o1)) (:goal (p o1)))")
+    report = diagnose(dom, prob)
+    assert report["valid"] is False
+    assert ("error", "durative") in _checks(report)
+    assert "non-positive duration" in str(report["issues"])
+
+
+def test_domain_without_predicates_skips_declaration_check(w):
+    dom = w("d.pddl", "(define (domain toy)"
+                      " (:action a :parameters (?x) :precondition (p ?x) :effect (p ?x)))")
+    prob = w("p.pddl", "(define (problem t) (:domain toy) (:objects o1)"
+                       " (:init (p o1)) (:goal (p o1)))")
+    report = diagnose(dom, prob)
+    assert ("error", "undeclared_predicate") not in _checks(report)

--- a/tests/test_mcpserver.py
+++ b/tests/test_mcpserver.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from pddlpy import mcpserver
-from pddlpy.mcpserver import ground, parse, server, solve
+from pddlpy.mcpserver import ground, parse, server, solve, validate
 
 CORPUS = os.path.join(os.path.dirname(__file__), "corpus")
 
@@ -63,9 +63,13 @@ def test_solve_unknown_planner():
 
 # --- through the MCP layer -------------------------------------------------
 
+def test_validate_clean_pair():
+    assert validate(*_files("blocksworld")) == {"valid": True, "issues": []}
+
+
 def test_tools_registered():
     tools = asyncio.run(server.list_tools())
-    assert sorted(t.name for t in tools) == ["ground", "parse", "solve"]
+    assert sorted(t.name for t in tools) == ["ground", "parse", "solve", "validate"]
     for t in tools:
         assert t.description  # every tool documents itself
 


### PR DESCRIPTION
Closes #94.

## What
A `validate` operation on both the CLI (`pddlpy validate DOMAIN PROBLEM`) and the MCP server (a fourth tool), giving agents a machine-checkable feedback step for the NL→PDDL translation loop.

## Why
A successful `parse` doesn't mean a translation is usable: ANTLR error-recovers (syntax errors only scroll past on stderr while a model still comes out), and semantically-off PDDL shows up as atoms over undeclared predicates or operators that ground to zero instances. Bundling these into one JSON verdict enables write-PDDL → validate → fix → solve.

## Changes
- **pddlpy/diagnostics.py** — `diagnose(domain, problem)` → `{valid, issues: [{severity, check, message}]}` with five checks:
  - `syntax` (error): ANTLR errors collected via a custom ErrorListener, for both files; semantic checks are skipped when present (the recovered model would mislead)
  - `undeclared_predicate` (error): atoms in init/goal/action/durative conditions and effects over predicates missing from `:predicates` (skipped when the domain declares none)
  - `unknown_object` (error): ground atoms in `:init`/`:goal` naming undeclared objects
  - `zero_groundings` (**warning** — legal but almost always a mistyped object/type/static predicate in agent-written PDDL)
  - `durative` (error): reuses `validate_durative_actions`
- **CLI**: `validate` subcommand; exit `0` clean, `1` issues found, `2` bad input
- **MCP**: `validate` tool with a description telling agents to run it after writing/editing PDDL
- **README + SKILL.md**: document the diagnostics and the agentic loop
- **Tests**: 12 new (direct `diagnose`, CLI paths, MCP registration); suite 184 passing, coverage 100%; ruff/mypy clean

## Reviewer notes
- `diagnostics.py` sits at the object-model layer, so importing the generated grammar is allowed (the layering test restricts only `pddlpy/planning/*`); module docstring states this.
- Issues are aggregated per predicate/object (not one per occurrence) and sorted, so output is deterministic.
- Found in passing, **not** touched here: `worldobjects()` on untyped domains includes predicate names as objects (e.g. blocksworld returns `handempty` as an object), which inflates groundings. Filed thinking for a follow-up — it only weakens `unknown_object` toward false negatives, never false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)