### PR TITLE
fix: worldobjects() leaks predicate names on untyped domains

### DIFF
--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -586,7 +586,8 @@ class DomainListener(pddlListener):
             for opn, oper in self.operators.items():
                 alls = oper.precondition_pos | oper.precondition_neg | oper.effect_pos | oper.effect_neg
                 for a in alls:
-                    for s in a.predicate:
+                    # skip a.predicate[0]: it is the predicate name, not an argument
+                    for s in a.predicate[1:]:
                         if s[0] != '?':
                             vs.add( (s, None) )
             self.objects = dict( vs)
@@ -669,11 +670,12 @@ class ProblemListener(pddlListener):
     def exitProblem(self, ctx):
         if not self.objects:
             vs = set()
+            # skip a.predicate[0]: it is the predicate name, not an argument
             for a in self.initialstate:
-                for s in a.predicate:
+                for s in a.predicate[1:]:
                     vs.add( (s, None) )
             for a in self.goals:
-                for s in a.predicate:
+                for s in a.predicate[1:]:
                     vs.add( (s, None) )
             self.objects = dict( vs )
 

--- a/pddlpy/test.py
+++ b/pddlpy/test.py
@@ -11,10 +11,17 @@ class TestStringMethods(unittest.TestCase):
         domprob = DomainProblem(self.domainfile, self.problemfile)
         all_grounded_opers = domprob.ground_operator("op2")
         for gop in all_grounded_opers:
-            if gop.precondition_pos == set( [('S','R','C'),('S','R','S')] ):
+            if gop.precondition_pos == set( [('S','B','C'),('S','B','A')] ):
                 self.assertTrue(True)
                 return
         self.assertFalse("Missed a value")
+
+    def test_worldobjects_excludes_predicate_names(self):
+        # Untyped domain/problem without :objects: world objects come from
+        # the constants in :init and :goal, never from predicate names.
+        domprob = DomainProblem(self.domainfile, self.problemfile)
+        self.assertEqual(domprob.worldobjects(),
+                         {'A': None, 'B': None, 'C': None})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,9 @@ def test_ground_operator(capsys):
     assert code == 0
     assert out["operator"] == "pick-up"
     groundings = out["groundings"]
+    # one grounding per world object -- predicate names must not bind ?x
+    assert len(groundings) == 3
+    assert {g["parameters"]["?x"] for g in groundings} == {"a", "b", "c"}
     g = next(g for g in groundings if g["parameters"] == {"?x": "a"})
     assert g["name"] == "pick-up"
     assert g["precondition_connective"] == "and"

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -76,6 +76,20 @@ def test_uppercase_keywords_parse():
     assert len(upper.initialstate()) == 7
 
 
+def test_untyped_worldobjects_exclude_predicate_names():
+    """Untyped domains must not leak predicate names into worldobjects():
+    blocksworld declares no :types and no :constants, so world objects are
+    exactly the :objects of the problem."""
+    dp = DomainProblem(
+        os.path.join(CORPUS, "blocksworld-domain.pddl"),
+        os.path.join(CORPUS, "blocksworld-problem.pddl"),
+    )
+    assert dp.worldobjects() == {"a": None, "b": None, "c": None}
+    groundings = list(dp.ground_operator("pick-up"))
+    assert len(groundings) == 3
+    assert {g.variable_list["?x"] for g in groundings} == {"a", "b", "c"}
+
+
 def test_trailing_comment_without_newline(tmp_path):
     """#19: a comment on the final line with no trailing newline must not
     break the lexer."""

--- a/tests/test_model_coverage.py
+++ b/tests/test_model_coverage.py
@@ -45,6 +45,29 @@ def test_negative_precondition(tmp_path):
     assert ("q", "?x") in eff_neg
 
 
+def test_untyped_domain_inline_constants(tmp_path):
+    # A domain with no :constants and no :types falls back to harvesting
+    # constants that appear inline as action arguments -- but never the
+    # predicate names themselves.
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(
+        """(define (domain idom)
+ (:requirements :strips)
+ (:predicates (at ?x ?l) (moved ?x))
+ (:action go-home :parameters (?x)
+   :precondition (at ?x home)
+   :effect (moved ?x)))"""
+    )
+    problem.write_text(
+        """(define (problem iprob) (:domain idom)
+ (:objects o1)
+ (:init (at o1 home)) (:goal (moved o1)))"""
+    )
+    dp = DomainProblem(str(domain), str(problem))
+    assert dp.worldobjects() == {"home": None, "o1": None}
+
+
 def test_operator_str(tmp_path):
     dp = _domprob(tmp_path)
     text = str(dp.domain.operators["a"])


### PR DESCRIPTION
## What
Fixes `DomainProblem.worldobjects()` wrongly including predicate names as world objects on untyped domains, which inflated `ground_operator()` results.

## Why
The untyped fallbacks in `DomainListener.exitDomain` and `ProblemListener.exitProblem` harvested every symbol of each atom — including `atom.predicate[0]`, the predicate name. Parsing `tests/corpus/blocksworld-domain.pddl` (no `:types`, no `:constants`) returned `{'a','b','c'}` plus `'clear'`, `'handempty'`, `'on'`, `'ontable'`, `'holding'`, so `ground_operator('pick-up')` yielded 8 groundings instead of 3, binding `?x` to predicate names.

## Changes
- `pddlpy/pddl.py`: both untyped fallbacks now iterate `a.predicate[1:]`, skipping the predicate name while still harvesting inline constants from argument positions (the fallback's intended purpose).
- `pddlpy/test.py`: `test_ground` asserted a grounding that bound variables to leaked predicate names (`?x3 = 'R'`); updated to a valid grounding over the real objects, and added an assertion that example-01 world objects are exactly `{A, B, C}`.
- `tests/test_cli.py`: tightened `test_ground_operator` to assert exactly 3 `pick-up` groundings with `?x ∈ {a, b, c}` (it previously tolerated the bug by picking the `?x == 'a'` grounding).
- `tests/test_corpus.py`: new regression test asserting blocksworld `worldobjects() == {'a': None, 'b': None, 'c': None}` and 3 `pick-up` groundings.
- `tests/test_model_coverage.py`: new test covering the inline-constant harvesting path (an untyped domain using `home` as an action argument), keeping `pddlpy/pddl.py` at 100% coverage.

`uv run pytest`: 187 passed, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)