### PR TITLE
release: 1.1.0 — CLI, MCP server, validate diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to `pddlpy` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-07-12
+
+The "standalone tool" release: pddlpy is now drivable from the shell, by MCP
+clients, and by coding agents — not only as a Python library.
+
+### Added
+- **CLI** (#85): a `pddlpy` console command with JSON output —
+  `pddlpy parse|ground|solve|validate DOMAIN PROBLEM`. `solve` takes
+  `--planner` (`bfs`/`astar`/`gbfs`/`ucs`, default `astar`). Exit codes:
+  `0` success, `1` no plan found / validation issues, `2` bad input.
+  Zero-install via `uvx pddlpy ...`.
+- **MCP server** (#86): `pddlpy-mcp` (stdio) exposing `parse`, `ground`,
+  `solve` and `validate` as Model Context Protocol tools with structured
+  JSON results. The `mcp` SDK is an optional extra: `pip install "pddlpy[mcp]"`.
+- **`validate` diagnostics** (#94): `pddlpy.diagnostics.diagnose()` bundles
+  collected ANTLR syntax errors, atoms over undeclared predicates, ground
+  atoms naming unknown objects, operators grounding to zero instances
+  (warning), and durative-action validation — the feedback step for agentic
+  natural-language → PDDL translation loops.
+- **`pddlpy.serialize`**: JSON-friendly dict renderings of `DomainProblem`,
+  grounded `Operator` and `Plan`, shared by the CLI and the MCP server.
+- **Agent Skill**: `skills/pddlpy/SKILL.md` reworked for standalone use
+  (installable via `npx skills add hfoffani/pddl-lib`), documenting the CLI
+  fast path and the write → validate → fix → solve loop.
+
+### Fixed
+- `worldobjects()` no longer includes predicate names as objects in untyped
+  domains, which inflated grounding (e.g. blocksworld `pick-up` grounded to
+  8 instances instead of 3) (#96).
+
+### Quality
+- 187 tests, 100% line coverage maintained.
+
 ## [1.0.0] - 2026-06-21
 
 First stable release. The library grew from a STRIPS parser into a parser +
@@ -48,4 +81,5 @@ public API (`Development Status :: 5 - Production/Stable`).
 - 150 tests, 100% line coverage; layering between grammar / model / planner enforced
   by a test. Python 3.11+.
 
+[1.1.0]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.1.0
 [1.0.0]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pddlpy"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python PDDL parser"
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/pddlpy/SKILL.md
+++ b/skills/pddlpy/SKILL.md
@@ -12,8 +12,14 @@ and action costs; durative actions are parsed but not solved.
 ## Setup
 
 ```bash
-uv sync          # install (project uses uv)
+pip install pddlpy              # library + `pddlpy` CLI (or: uv pip install pddlpy)
+pip install "pddlpy[mcp]"       # optional: also the MCP server (`pddlpy-mcp`)
 ```
+
+The CLI/MCP/validate surface needs pddlpy >= 1.1; `uvx pddlpy ...` runs the
+CLI with zero install. Working inside a checkout of the
+[pddl-lib repo](https://github.com/hfoffani/pddl-lib) instead: `uv sync`,
+then prefix commands with `uv run`.
 
 Import: `from pddlpy import DomainProblem` and `from pddlpy.planning import get`.
 
@@ -37,13 +43,12 @@ over undeclared predicates, unknown objects, operators grounding to zero
 instances, and malformed durative actions. Exit `0` = clean, `1` = issues
 in the JSON `issues` list.
 
-In this repo run it as `uv run pddlpy ...`; outside, `uvx pddlpy ...` works
-once a release containing the CLI is on PyPI. Exit codes: `0` success, `1`
-search found no plan, `2` bad input (missing file, unknown operator/planner,
-unsupported `:requirements`). Drop to the Python API below when you need
-`State`/`GroundedTask`, custom binders, or anything the three subcommands
-don't cover. (There is also an MCP server, `pddlpy-mcp`, exposing the same
-three operations as tools — `pip install "pddlpy[mcp]"`.)
+Exit codes: `0` success, `1` search found no plan / validate found issues,
+`2` bad input (missing file, unknown operator/planner, unsupported
+`:requirements`). Drop to the Python API below when you need
+`State`/`GroundedTask`, custom binders, or anything the subcommands don't
+cover. (The MCP server `pddlpy-mcp` exposes the same four operations as
+tools over stdio.)
 
 ## Parse a domain + problem
 
@@ -112,7 +117,7 @@ s.applicable(op); s.apply(op)              # no manual Atom/tuple casting
 - Uppercase keywords (`(:INIT ...)`) are fine — keywords are case-insensitive;
   identifiers keep their case.
 
-## Commands
+## Developing pddl-lib itself (repo checkout only)
 
 ```bash
 make            # grammar + python tests
@@ -121,4 +126,5 @@ make lint       # ruff
 make typecheck  # mypy
 ```
 
-See `docs/object-model.md` for the full model reference.
+Full model reference:
+[docs/object-model.md](https://github.com/hfoffani/pddl-lib/blob/main/docs/object-model.md).

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "pddlpy"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## What
Version bump to **1.1.0** + changelog for the "standalone tool" release: CLI (#85), MCP server (#86), `validate` diagnostics (#94), the shared serialize module, the standalone agent skill, and the untyped-`worldobjects()` grounding fix (#96/#98).

## Also fixes a stranded merge
PR #97 (standalone skill) hit the same stacked-merge trap as #91 earlier: it merged into `validate-94` *after* that branch had landed on main, so its content never reached main. This PR folds it in via a merge of `origin/validate-94` — `skills/pddlpy/SKILL.md` on main will finally match what #97 shipped.

## QA done on this branch
- `make` green: grammar + **187 tests, 100% coverage**
- `make build`: wheel + sdist for 1.1.0
- Wheel smoke-tested in a clean venv with the `[mcp]` extra: `pddlpy validate`/`solve` work, `pddlpy-mcp` registers all four tools, both console scripts installed
- `uv.lock` refreshed

## After merge
I'll publish TestPyPI → verify → PyPI (`make pypitest` / `make pypipublish`), tag `v1.1.0`, and create the GitHub release with these notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)