### PR TITLE
docs(skill): hide run-pddlpy from public skills discovery

### DIFF
--- a/.claude/skills/run-pddlpy/SKILL.md
+++ b/.claude/skills/run-pddlpy/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: run-pddlpy
 description: Run, test, build, or smoke-check the pddlpy PDDL parser library. Use when asked to run pddlpy/pddl-lib, parse a PDDL domain/problem, exercise the DomainProblem API, ground operators, regenerate the ANTLR parser, or build the wheel.
+metadata:
+  internal: true
 ---
 
 # Run pddlpy


### PR DESCRIPTION
## What
Add `metadata.internal: true` to `.claude/skills/run-pddlpy/SKILL.md`.

## Why
`npx skills add hfoffani/pddl-lib` scans `.claude/skills/` in addition to `skills/`, so the install picker was offering **two** skills: the public `pddlpy` skill and `run-pddlpy` — an internal dev-workflow skill (assumes a repo checkout: `uv sync`, `make`, corpus paths) that would only confuse consumers. The skills CLI documents `metadata.internal: true` as the way to hide a skill from normal discovery.

## Effect
- `npx skills add hfoffani/pddl-lib` offers exactly one skill: `pddlpy`
- `run-pddlpy` keeps working unchanged for Claude Code sessions inside this repo

## Note
`.claude/` is in `.gitignore` but these two skill files were deliberately force-added and are tracked — the change is committed with `git add -f` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)