### PR TITLE
#99: docs — an LLM and pddlpy working together

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,23 @@ optional `planner` argument (`bfs`, `astar`, `gbfs`, `ucs`). For agents
 translating natural language to PDDL, `validate` provides the fix-loop
 feedback (syntax, undeclared predicates, unknown objects, zero groundings).
 
+**Why pair an LLM with a solver at all?** LLMs translate problems into PDDL
+very well but are unreliable at producing (let alone *optimal*) plans;
+delegating the search to a classical solver combines the strengths of both.
+[`docs/llm-interaction.md`](docs/llm-interaction.md) walks through a complete
+worked example — natural language → PDDL → `pddlpy solve` → natural language —
+on a small cost-optimal routing problem where the intuitive answer is wrong.
+Background reading: *LLM+P* ([arXiv:2304.11477](https://arxiv.org/abs/2304.11477)),
+the paper behind this pipeline, and *PlanBench*
+([arXiv:2206.10498](https://arxiv.org/abs/2206.10498)) on why direct LLM
+planning falls short.
+
 ### Documentation ###
 
 * [`docs/object-model.md`](docs/object-model.md) — full reference for the
   parser object model and the planning layer.
+* [`docs/llm-interaction.md`](docs/llm-interaction.md) — worked example of an
+  LLM and pddlpy dividing the work: translate, solve, translate back (#99).
 * [`skills/pddlpy/SKILL.md`](skills/pddlpy/SKILL.md) — an Agent Skill so coding
   agents can drive the library (parse, ground, plan).
 

--- a/docs/llm-interaction.md
+++ b/docs/llm-interaction.md
@@ -1,0 +1,156 @@
+# An LLM and pddlpy, working together (#99)
+
+LLMs are excellent **translators** and unreliable **planners**. They turn a
+problem told in plain language into formal PDDL very well, but producing the
+plan itself requires systematic search — and when costs are involved, a
+plausible-sounding answer is not the same as the *cheapest* one. A classical
+solver is the opposite: it cannot read your problem, but its answer comes
+with a guarantee.
+
+This page walks through the division of labour: **the LLM translates, pddlpy
+solves, the LLM translates back.** The point is deliberately model-agnostic.
+Frontier models keep getting better at planning, and this library does not
+compete with them — it doesn't have to. Whether you drive it from a
+top-of-the-line model or a small open-source one running locally, the solver
+contributes the same thing the LLM cannot: a **provably optimal** answer.
+The weaker the model, the more the solver adds; the stronger the model, the
+cheaper it is to let the solver settle what would otherwise need a long,
+unverifiable chain of reasoning.
+
+> **What is simulated and what is real.** The conversation below is a
+> *simulation* — a scripted illustration of the back-and-forth, not a
+> transcript of one specific model (any LLM wired to the
+> [CLI](../README.md#command-line-interface), the
+> [MCP server](../README.md#mcp-server) or the
+> [Agent Skill](../skills/pddlpy/SKILL.md) can play this role). Every
+> **command and output, however, is real**: the PDDL files live in
+> [`examples/pddl/`](../examples/pddl/), the outputs were produced by
+> `pddlpy` 1.1, and a unit test keeps them honest.
+
+## 1. The user states the problem
+
+> **User:** A courier is at the **depot** and must deliver a parcel to
+> **town**, spending as little as possible on tolls. The direct highway
+> costs **10**. There's a route through the **junction**: 5 to get there,
+> then 6 into town. And there's a back-road chain: **riverside** (2), then
+> the **old bridge** (2), then into town (3). Roads are one-way. What's the
+> cheapest route?
+
+Small as it is, this is an *optimization* problem. An answer is only correct
+if no cheaper route exists — something you can't see from the answer itself.
+
+## 2. The LLM answers directly (and why you shouldn't settle for that)
+
+> **LLM (answering from intuition):** Take the route through the junction:
+> 5 + 6 = **11**, cheaper than the 10 highway... actually, comparing again,
+> take the **direct highway for 10** — it beats the junction route.
+
+The highway *does* beat the junction route — the decoy did its job — and yet
+**10 is not the answer**: the three-hop back road costs 2 + 2 + 3 = **7**. On
+five places you can check this by hand. On fifty, you cannot, and the LLM's
+answer doesn't come with a proof either way. (This failure mode is
+well-documented; see the [references](#references) below.)
+
+## 3. The LLM translates the problem to PDDL instead
+
+> **LLM:** Rather than trusting my arithmetic, let me write this down
+> formally and let a solver find the optimum.
+
+It emits two files — a *domain* (what actions exist) and a *problem* (this
+particular map and goal): [`courier-domain.pddl`](../examples/pddl/courier-domain.pddl)
+and [`courier-problem.pddl`](../examples/pddl/courier-problem.pddl). The
+essence:
+
+```lisp
+(:action drive
+  :parameters (?from - place ?to - place)
+  :precondition (and (at ?from) (road ?from ?to))
+  :effect (and (not (at ?from)) (at ?to)
+               (increase (total-cost) (toll ?from ?to))))
+```
+
+```lisp
+(:init (at depot)
+  (road depot town)          (= (toll depot town) 10)
+  (road depot junction)      (= (toll depot junction) 5)
+  (road junction town)       (= (toll junction town) 6)
+  (road depot riverside)     (= (toll depot riverside) 2)
+  (road riverside oldbridge) (= (toll riverside oldbridge) 2)
+  (road oldbridge town)      (= (toll oldbridge town) 3)
+  (= (total-cost) 0))
+(:goal (at town))
+(:metric minimize (total-cost))
+```
+
+## 4. The LLM checks its own translation
+
+Freshly written PDDL deserves a lint before a solve — a typo'd predicate or
+an undeclared object would otherwise surface as a confusing "no plan":
+
+```console
+$ pddlpy validate courier-domain.pddl courier-problem.pddl
+{
+  "valid": true,
+  "issues": []
+}
+```
+
+(Had it mistyped `raod`, `validate` would exit `1` and name the undeclared
+predicate — the fix-loop for agent-written PDDL. See the
+[README](../README.md#command-line-interface).)
+
+## 5. The solver finds the optimum
+
+`ucs` is uniform-cost search: cost-optimal for `:action-costs` domains.
+
+```console
+$ pddlpy solve courier-domain.pddl courier-problem.pddl --planner ucs
+{
+  "planner": "ucs",
+  "solved": true,
+  "cost": 7.0,
+  "length": 3,
+  "steps": [
+    {"action": "drive", "args": {"?from": "depot",     "?to": "riverside"}},
+    {"action": "drive", "args": {"?from": "riverside", "?to": "oldbridge"}},
+    {"action": "drive", "args": {"?from": "oldbridge", "?to": "town"}}
+  ]
+}
+```
+
+Not an opinion: no cheaper plan exists in this model.
+
+## 6. The LLM translates the plan back
+
+> **LLM:** The cheapest delivery costs **7 tolls**, not 10: drive from the
+> depot to **riverside** (2), cross the **old bridge** (2), and continue
+> into **town** (3). The direct highway (10) and the junction route (11)
+> are both more expensive.
+
+This last step is the easy direction — turning three JSON steps back into a
+sentence — and it's where the LLM shines regardless of its size.
+
+## Running it yourself
+
+The same loop works over any of the three surfaces:
+
+```bash
+uvx pddlpy validate courier-domain.pddl courier-problem.pddl   # zero-install CLI
+uvx pddlpy solve    courier-domain.pddl courier-problem.pddl --planner ucs
+```
+
+or give an agent the `validate` / `solve` tools via the MCP server
+(`pddlpy-mcp`), or install the Agent Skill
+(`npx skills add hfoffani/pddl-lib`) so a coding agent knows this recipe.
+
+## References
+
+- Liu et al., *LLM+P: Empowering Large Language Models with Optimal Planning
+  Proficiency*, 2023 — [arXiv:2304.11477](https://arxiv.org/abs/2304.11477).
+  The pipeline shown here: LLM translates NL→PDDL, a classical planner
+  solves, the LLM narrates the plan.
+- Valmeekam et al., *PlanBench: An Extensible Benchmark for Evaluating Large
+  Language Models on Planning and Reasoning about Change*, NeurIPS 2023 —
+  [arXiv:2206.10498](https://arxiv.org/abs/2206.10498). Systematic evidence
+  that direct LLM planning degrades quickly with problem size and
+  unfamiliar domains.

--- a/examples/pddl/courier-domain.pddl
+++ b/examples/pddl/courier-domain.pddl
@@ -1,0 +1,19 @@
+;; Courier domain for docs/llm-interaction.md (#99): moving between connected
+;; places accrues total-cost equal to the road toll. Deliberately tiny -- the
+;; point of the example is cost-OPTIMAL routing, where greedy answers fail.
+(define (domain courier)
+  (:requirements :strips :typing :action-costs)
+  (:types place)
+  (:predicates
+    (at ?p - place)
+    (road ?from - place ?to - place))
+  (:functions
+    (total-cost)
+    (toll ?from - place ?to - place))
+
+  (:action drive
+    :parameters (?from - place ?to - place)
+    :precondition (and (at ?from) (road ?from ?to))
+    :effect (and (not (at ?from))
+                 (at ?to)
+                 (increase (total-cost) (toll ?from ?to)))))

--- a/examples/pddl/courier-problem.pddl
+++ b/examples/pddl/courier-problem.pddl
@@ -1,0 +1,18 @@
+;; The optimality trap (#99): the direct highway depot->town costs 10.
+;; The scenic detour depot->riverside->oldbridge->town costs 2+2+3 = 7.
+;; A decoy route depot->junction->town costs 5+6 = 11 (looks promising,
+;; is not). Cheapest plan: the three-hop detour, total 7.
+(define (problem courier-run)
+  (:domain courier)
+  (:objects depot riverside oldbridge junction town - place)
+  (:init
+    (at depot)
+    (road depot town)        (= (toll depot town) 10)
+    (road depot junction)    (= (toll depot junction) 5)
+    (road junction town)     (= (toll junction town) 6)
+    (road depot riverside)   (= (toll depot riverside) 2)
+    (road riverside oldbridge) (= (toll riverside oldbridge) 2)
+    (road oldbridge town)    (= (toll oldbridge town) 3)
+    (= (total-cost) 0))
+  (:goal (at town))
+  (:metric minimize (total-cost)))

--- a/tests/test_llm_doc.py
+++ b/tests/test_llm_doc.py
@@ -1,0 +1,36 @@
+"""docs/llm-interaction.md (#99) stays honest: its commands really produce
+the documented outputs — the courier pair validates clean and ucs finds the
+7-cost three-hop detour, beating the direct highway (10) and the decoy (11).
+"""
+import json
+import os
+
+from pddlpy.cli import main
+
+PDDL = os.path.join(os.path.dirname(__file__), os.pardir, "examples", "pddl")
+DOMAIN = os.path.join(PDDL, "courier-domain.pddl")
+PROBLEM = os.path.join(PDDL, "courier-problem.pddl")
+
+
+def _run(capsys, *argv):
+    code = main(list(argv))
+    return code, json.loads(capsys.readouterr().out)
+
+
+def test_courier_pair_validates_clean(capsys):
+    code, out = _run(capsys, "validate", DOMAIN, PROBLEM)
+    assert code == 0
+    assert out == {"valid": True, "issues": []}
+
+
+def test_ucs_beats_the_intuitive_answers(capsys):
+    code, out = _run(capsys, "solve", DOMAIN, PROBLEM, "--planner", "ucs")
+    assert code == 0
+    assert out["solved"] is True
+    assert out["cost"] == 7.0  # < 10 (direct highway) and < 11 (junction decoy)
+    hops = [(s["args"]["?from"], s["args"]["?to"]) for s in out["steps"]]
+    assert hops == [
+        ("depot", "riverside"),
+        ("riverside", "oldbridge"),
+        ("oldbridge", "town"),
+    ]


### PR DESCRIPTION
Closes #99.

## What
`docs/llm-interaction.md` — the conversation the issue asks for: a user states a problem in natural language, the LLM translates to PDDL, calls `pddlpy validate` + `pddlpy solve`, and narrates the plan back. Linked from the README (MCP section + Documentation list) with the LLM+P and PlanBench paper references.

## Design (as agreed)
- **Optimality trap**: 5 places, one courier. Direct highway = 10; junction decoy = 5+6 = 11; back road = 2+2+3 = **7**. The simulated LLM dodges the decoy, lands on the highway (10)… and is still wrong — `ucs` provably finds 7. Small to state, wrong by intuition.
- **Simulation, honestly labeled**: the dialogue is explicitly marked as a scripted, model-agnostic illustration; every command and output is real and reproducible from `examples/pddl/courier-*.pddl`.
- **Humble framing**: the doc doesn't claim to beat frontier models — the solver contributes what no LLM of any size does: a guarantee. Works the same whether the driver is a frontier model or a small local one.

## Changes
- `docs/llm-interaction.md` — the walkthrough (validate step included, showing the agent fix-loop)
- `examples/pddl/courier-domain.pddl` / `courier-problem.pddl` — the trap, commented
- `tests/test_llm_doc.py` — pins the documented outputs (validate clean; ucs cost 7.0 with the exact 3-hop route), so the doc can't silently rot
- README — "Why pair an LLM with a solver at all?" paragraph with [arXiv:2304.11477](https://arxiv.org/abs/2304.11477) (LLM+P) and [arXiv:2206.10498](https://arxiv.org/abs/2206.10498) (PlanBench), plus a Documentation entry

Suite: 189 passed, coverage 100%, ruff clean.

## Found in passing (separate issue coming)
Writing the example files surfaced a real bug: `DomainProblem` (and `diagnose`) crash with `UnicodeDecodeError` on any PDDL file containing non-ASCII bytes — ANTLR's `FileStream` defaults to ASCII. A comment like `; camión` breaks parsing. Not fixed here to keep the PR focused; the example files are ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)