### PR TITLE
#103: parse PDDL files as UTF-8

### DIFF
--- a/pddlpy/diagnostics.py
+++ b/pddlpy/diagnostics.py
@@ -39,7 +39,7 @@ def _syntax_errors(path: str, rule: str) -> List[str]:
     """Parse ``path`` with the grammar rule ``rule`` ('domain' or 'problem')
     and return the collected syntax errors."""
     collector = _CollectingErrorListener()
-    lexer = pddlLexer(FileStream(path))
+    lexer = pddlLexer(FileStream(path, encoding="utf-8"))  # UTF-8 PDDL, #103
     lexer.removeErrorListeners()
     lexer.addErrorListener(collector)
     parser = pddlParser(CommonTokenStream(lexer))

--- a/pddlpy/pddl.py
+++ b/pddlpy/pddl.py
@@ -694,7 +694,9 @@ class DomainProblem():
                   the .binder attribute later, to override grounding.
         """
         # domain
-        inp = FileStream(domainfile)
+        # ANTLR's FileStream defaults to ASCII; PDDL files may carry UTF-8
+        # (typically in comments) -- see #103.
+        inp = FileStream(domainfile, encoding="utf-8")
         lexer = pddlLexer(inp)
         stream = CommonTokenStream(lexer)
         parser = pddlParser(stream)
@@ -703,7 +705,7 @@ class DomainProblem():
         walker = ParseTreeWalker()
         walker.walk(self.domain, tree)
         # problem
-        inp = FileStream(problemfile)
+        inp = FileStream(problemfile, encoding="utf-8")
         lexer = pddlLexer(inp)
         stream = CommonTokenStream(lexer)
         parser = pddlParser(stream)

--- a/tests/test_utf8.py
+++ b/tests/test_utf8.py
@@ -1,0 +1,49 @@
+"""UTF-8 PDDL files parse (#103): non-ASCII comments must not crash.
+
+ANTLR's FileStream defaults to ASCII, which made a comment like
+``; camión`` raise UnicodeDecodeError before parsing started.
+"""
+import pytest
+
+from pddlpy import DomainProblem
+from pddlpy.diagnostics import diagnose
+from pddlpy.planning import get
+
+DOMAIN = """\
+; dominio del camión — mueve paquetes entre sitios ✓
+(define (domain reparto)
+  (:predicates (en ?x) (meta ?x))
+  (:action ir
+    :parameters (?x)
+    :precondition (en ?x)
+    :effect (and (not (en ?x)) (meta ?x))))
+"""
+
+PROBLEM = """\
+; problema: llegar a la meta — ¡fácil!
+(define (problem uno)
+  (:domain reparto)
+  (:objects sitio)
+  (:init (en sitio))
+  (:goal (meta sitio)))
+"""
+
+
+@pytest.fixture
+def utf8_pair(tmp_path):
+    domain = tmp_path / "d.pddl"
+    problem = tmp_path / "p.pddl"
+    domain.write_text(DOMAIN, encoding="utf-8")
+    problem.write_text(PROBLEM, encoding="utf-8")
+    return str(domain), str(problem)
+
+
+def test_utf8_comments_parse_and_solve(utf8_pair):
+    dp = DomainProblem(*utf8_pair)
+    assert list(dp.operators()) == ["ir"]
+    plan = get("bfs").solve(dp)
+    assert plan is not None and len(plan) == 1
+
+
+def test_utf8_comments_diagnose_clean(utf8_pair):
+    assert diagnose(*utf8_pair) == {"valid": True, "issues": []}


### PR DESCRIPTION
Closes #103.

## What
Pass `encoding="utf-8"` to ANTLR's `FileStream` at all three call sites: the domain and problem reads in `DomainProblem.__init__` and the re-parse in `diagnostics._syntax_errors`.

## Why
`FileStream` defaults to ASCII, so any PDDL file containing a non-ASCII byte — even just a comment like `; camión` or an em-dash — crashed with `UnicodeDecodeError` before parsing started. Found while writing #99's example files (an em-dash in a comment took down `pddlpy validate`).

## Changes
- `pddlpy/pddl.py`: two `FileStream(..., encoding="utf-8")` (with a comment citing #103)
- `pddlpy/diagnostics.py`: same for the syntax-error collector
- `tests/test_utf8.py`: a Spanish-commented domain/problem pair (accents, ¡!, ✓, em-dash) parses, solves with bfs, and diagnoses clean

## Notes
- UTF-8 is a strict superset of ASCII — every previously working file parses identically; no behavior change for identifiers, only for bytes that previously crashed.
- Suite: 189 passed on this branch (187 from main + 2 new), coverage 100%, ruff/mypy clean.
- Independent of PR #102 (both branch off main; no shared files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)