### PR TITLE
release: 1.1.1 — UTF-8 parsing fix, LLM interaction doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to `pddlpy` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.1.1] - 2026-07-12
+
+### Fixed
+- **UTF-8 PDDL files parse** (#103): ANTLR's `FileStream` defaults to ASCII,
+  so any non-ASCII byte — even in a comment like `; camión` — raised
+  `UnicodeDecodeError` before parsing started. Files are now read as UTF-8
+  (a strict ASCII superset; existing files parse unchanged).
+
+### Added
+- **LLM ↔ pddlpy worked example** (#99): `docs/llm-interaction.md` — natural
+  language → PDDL → `pddlpy solve` → natural language, on a small cost-optimal
+  routing problem where the intuitive answer is wrong; courier example PDDL
+  under `examples/pddl/`, linked from the README with LLM+P / PlanBench
+  references. The `run-pddlpy` dev skill is hidden from public skills
+  discovery (`metadata.internal`).
+
+### Quality
+- 191 tests, 100% line coverage maintained.
+
 ## [1.1.0] - 2026-07-12
 
 The "standalone tool" release: pddlpy is now drivable from the shell, by MCP
@@ -81,5 +100,6 @@ public API (`Development Status :: 5 - Production/Stable`).
 - 150 tests, 100% line coverage; layering between grammar / model / planner enforced
   by a test. Python 3.11+.
 
+[1.1.1]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.1.1
 [1.1.0]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.1.0
 [1.0.0]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pddlpy"
-version = "1.1.0"
+version = "1.1.1"
 description = "Python PDDL parser"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "pddlpy"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
Version bump + changelog for **1.1.1**.

## In this release
- **Fixed** (#103): PDDL files are read as UTF-8 — non-ASCII bytes (e.g. `; camión`) no longer crash `DomainProblem`/`diagnose` with `UnicodeDecodeError`. This is the patch that motivates the release; it changes the published wheel.
- **Added** (#99): `docs/llm-interaction.md` + courier example (docs only, not in the wheel); `run-pddlpy` hidden from public skills discovery.

## QA on this branch
- `make` green: 191 tests, 100% coverage
- Wheel smoke-tested in a clean venv with `[mcp]`: a UTF-8-commented pair validates clean (the bug is fixed in the artifact), courier solves at cost 7.0, all four MCP tools registered

Publishing (TestPyPI → PyPI), tag `v1.1.1`, and the GitHub release follow the same flow as 1.1.0 — artifacts are unaffected by this PR's changelog text, so publish proceeds in parallel with review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)