### PR TITLE
ci: bump actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       # Generate the ANTLR parser BEFORE uv sync: the editable build
       # force-includes pddlpy/pddlLexer.py etc., which are gitignored.
       - name: Generate ANTLR parser

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,14 +9,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Java is needed to compile the ANTLR grammar and regenerate the
       # parser (the generated pddlLexer/Parser/Listener are gitignored).
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
       # Generate the ANTLR parser BEFORE uv sync: the editable build
       # force-includes pddlpy/pddlLexer.py etc., which are gitignored.
       - name: Generate ANTLR parser

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - name: Tag must match pyproject version
         run: |
           V=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
       - name: Tag must match pyproject version
         run: |
           V=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)
@@ -33,7 +33,7 @@ jobs:
         run: uv run --group dev pytest -q
       - name: Build wheel + sdist
         run: uv build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -47,7 +47,7 @@ jobs:
     permissions:
       id-token: write # OIDC for Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -64,7 +64,7 @@ jobs:
     permissions:
       id-token: write # OIDC for Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Closes #110.

## What
Bump every pinned action to its current Node-24 floating major, clearing the deprecation warnings from the v1.1.2 publish run:

| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-java | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| astral-sh/setup-uv | v5 | **v7** |

## Notes
- First attempt used `setup-uv@v8` and failed at job setup: astral-sh publishes floating major aliases only up to `v7` (`v8.x.y` exist only as exact release tags). `v7`'s `action.yml` declares `node24`, which is all #110 needs.
- CI on this PR is green in 41s with **zero annotations** — the warnings are gone for checkout / setup-java / setup-uv.
- upload/download-artifact only execute in the publish workflow, so their bumps get exercised by the next tag; both are on the same modern artifact backend (v4+), so cross-version transfer within a run is supported.
- `pypa/gh-action-pypi-publish@release/v1` stays: it's a floating release branch, already current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)