### PR TITLE
e2e: survive malformed tool-call JSON; record small-model results

### DIFF
--- a/e2e/llm/README.md
+++ b/e2e/llm/README.md
@@ -36,6 +36,17 @@ same MCP server through the agent's own harness:
 The driver prints where it saved the transcript; judge soundness with the
 same criteria (validate used, cost 7.0, route narrated).
 
+## Observed results
+
+| Model | Rounds | Outcome |
+|---|---|---|
+| `qwen/qwen-2.5-72b-instruct` | 2 | R1 **unsound** (double-escaped newlines, invented `:cost` syntax → harness hardened). R2 **sound**: wrote clean PDDL, recovered from a real `solve` rejection (missing `:typing`), narrated the optimum — now the transcript in `docs/llm-interaction.md`. |
+| `meta-llama/llama-3.1-8b-instruct` | 3 | All **unsound**, each differently: mangled the map + drifted into pseudo-code instead of tool calls; emitted malformed JSON tool arguments (now answered with an error result instead of crashing); fired 7 tool calls in one batch without reading any result. |
+
+The gap is the point: the 72B model *uses* the fix loop, the 8B model can't
+drive it — and the soundness gate correctly refused every unsound round.
+Below ~8B, the missing skill isn't PDDL, it's sustained tool use.
+
 ## Iterating (issue steps 5–8)
 
 Repeat runs (vary model / round) until a transcript is sound *and reads

--- a/e2e/llm/harness.py
+++ b/e2e/llm/harness.py
@@ -248,9 +248,17 @@ async def main() -> int:
                         break
                     for tc in calls:
                         fn = tc["function"]
-                        fargs = json.loads(fn["arguments"])
-                        result = await run_tool(session, workdir, fn["name"], fargs)
-                        convo.tool_results.append((fn["name"], fargs, result))
+                        # Small models emit malformed JSON arguments; answer
+                        # with an error result instead of crashing the run.
+                        try:
+                            fargs = json.loads(fn["arguments"])
+                            result = await run_tool(session, workdir,
+                                                    fn["name"], fargs)
+                            convo.tool_results.append((fn["name"], fargs, result))
+                        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+                            result = ("Error: tool call arguments were not valid "
+                                      "JSON (%s). Repeat the call with valid, "
+                                      "complete JSON arguments." % exc)
                         convo.messages.append({"role": "tool",
                                                "tool_call_id": tc["id"],
                                                "content": result})


### PR DESCRIPTION
Follow-up to #113/#116, from testing the smaller model as discussed.

## What happened
Three rounds with `meta-llama/llama-3.1-8b-instruct` (the suggested small model), all **unsound**, each failing differently:
1. Mangled the road map in PDDL, then drifted into writing *pseudo-code about calling tools* instead of calling them
2. Emitted **malformed JSON in tool-call arguments** — which crashed the harness (bug, fixed here: such calls now get an error tool-result so the model can retry)
3. Fired 7 tool calls in a single batch (write+write+validate+write+write+solve+parse) without reading any result, then stopped

## Why it's worth recording
It sharpens the doc's thesis with data: qwen-72b needed the fix loop and *used* it (sound on round 2); llama-8b can't sustain the loop at all — and the soundness gate correctly rejected every round. The e2e README now carries an observed-results table.

## Changes
- `harness.py`: malformed tool-call JSON → error tool-result instead of a crash (`--dry-run` still green)
- `e2e/llm/README.md`: observed-results table

Transcripts of the failed rounds stay local/gitignored as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)