### PR TITLE
release: 1.2.1 — serialize TemporalPlan schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to `pddlpy` are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-07-14
+
+Patch release found in the v1.2.0 post-release check.
+
+### Fixed
+- **CLI/MCP temporal output** (#119): `pddlpy solve --planner temporal` and
+  the MCP `solve` tool now render the `TemporalPlan` schedule — each step
+  carries `start`, `duration` and `end`, and the result a top-level
+  `makespan` (the generic `cost` is kept for compatibility). Previously the
+  JSON showed only `{action, args}` per step and the schedule was lost.
+
+### Quality
+- 234 tests, 100% line coverage maintained.
+
 ## [1.2.0] - 2026-07-13
 
 The planning release: durative actions are *solved* and the expressiveness
@@ -144,6 +158,7 @@ public API (`Development Status :: 5 - Production/Stable`).
 - 150 tests, 100% line coverage; layering between grammar / model / planner enforced
   by a test. Python 3.11+.
 
+[1.2.1]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.2.1
 [1.2.0]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.2.0
 [1.1.2]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.1.2
 [1.1.1]: https://github.com/hfoffani/pddl-lib/releases/tag/v1.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pddlpy"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python PDDL parser"
 readme = "README.md"
 license = {text = "MIT"}

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "pddlpy"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
## What
Patch release 1.2.1: version bump + CHANGELOG for the #119 fix (PR #123).

## Why
v1.2.0 post-release check found that `pddlpy solve --planner temporal` and the MCP `solve` tool dropped the `TemporalPlan` schedule from the JSON output; #123 fixed it and this ships it.

## Changes
- `pyproject.toml`: version 1.2.0 → 1.2.1 (+ `uv.lock`)
- `CHANGELOG.md`: 1.2.1 entry and release link

QA done: 234 tests green (100% coverage), `make build` OK, 1.2.1 wheel smoke-tested in a clean venv (temporal solve emits the schedule).

After merge: tag `v1.2.1` → publish.yaml (TestPyPI → PyPI, `pypi` env needs manual approval) → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)